### PR TITLE
Make repository into standard plugin package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from setuptools import setup, find_packages
+
+entry_points = """
+[glue.plugins]
+vispy_volume=vispy_volume:setup
+"""
+
+setup(name='glue-3d-viewer',
+      version="0.1.dev0",
+      description = "Experimental VisPy plugin for glue",
+      packages = find_packages(),
+      package_data={'': ['*.ui'], '': ['*.png']},
+      entry_points=entry_points
+    )

--- a/vispy_volume/__init__.py
+++ b/vispy_volume/__init__.py
@@ -1,1 +1,6 @@
 __author__ = 'penny'
+
+def setup():
+    from glue_viewer import GlueVispyViewer
+    from glue.config import qt_client
+    qt_client.add(GlueVispyViewer)

--- a/vispy_volume/__init__.py
+++ b/vispy_volume/__init__.py
@@ -1,6 +1,6 @@
 __author__ = 'penny'
 
 def setup():
-    from glue_viewer import GlueVispyViewer
+    from .glue_viewer import GlueVispyViewer
     from glue.config import qt_client
     qt_client.add(GlueVispyViewer)

--- a/vispy_volume/glue_viewer.py
+++ b/vispy_volume/glue_viewer.py
@@ -20,6 +20,3 @@ class GlueVispyViewer(DataViewer):
         self._vispy_widget.set_canvas()
         self._vispy_widget.canvas.render()
         return True
-
-from glue.config import qt_client
-qt_client.add(GlueVispyViewer)


### PR DESCRIPTION
At the moment, the glue functionality is configured using the `config.py` file. Instead, we should switch to making this a proper Python package with a `setup.py` file that also defines an entry point to load the plugin. You can see how this is done here:

https://github.com/glue-viz/glue-exp

I still need to write documentation to explain this a bit better.

I can volunteer to work on this (I've assigned myself on the right, which means I'll do it)
