### PR TITLE
Add a simple side panel & Camera settings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import os
 from setuptools import setup, find_packages
 
 entry_points = """
@@ -15,6 +14,6 @@ setup(name='glue-3d-viewer',
       description = "Experimental VisPy plugin for glue",
       # packages = find_packages(),
       packages = ['vispy_volume'],
-      package_data={'vispy_volume': ['*.ui'], 'vispy_volume': ['*.png']},
+      package_data={'vispy_volume': ['*.ui']},
       entry_points=entry_points
     )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import os
 from setuptools import setup, find_packages
 
 entry_points = """
@@ -12,7 +13,8 @@ vispy_volume=vispy_volume:setup
 setup(name='glue-3d-viewer',
       version="0.1.dev0",
       description = "Experimental VisPy plugin for glue",
-      packages = find_packages(),
-      package_data={'': ['*.ui'], '': ['*.png']},
+      # packages = find_packages(),
+      packages = ['vispy_volume'],
+      package_data={'vispy_volume': ['*.ui'], 'vispy_volume': ['*.png']},
       entry_points=entry_points
     )

--- a/vispy_volume/glue_viewer.py
+++ b/vispy_volume/glue_viewer.py
@@ -3,7 +3,6 @@ import numpy as np
 from glue.qt.widgets.data_viewer import DataViewer
 from glue.core import message as msg
 
-# Add a __init__.py file to this folder can solve the relative import problem
 from .vispy_widget import QtVispyWidget
 from .options_widget import VolumeOptionsWidget
 
@@ -16,9 +15,8 @@ class GlueVispyViewer(DataViewer):
         self._vispy_widget = QtVispyWidget()
         self._canvas = self._vispy_widget.canvas
         self._canvas.size = self.viewer_size
-        # self.viewer_size = self._canvas.size
-        # self._canvas.update()
         self.setCentralWidget(self._canvas.native)
+
         self._data = None
         self._subsets = []
         self._options_widget = VolumeOptionsWidget(vispy_widget=self._vispy_widget)
@@ -44,9 +42,6 @@ class GlueVispyViewer(DataViewer):
 
     def add_data(self, data):
         self._data = data['PRIMARY']
-        initial_level = "{0:.3g}".format(np.nanpercentile(data['PRIMARY'], 99))
-        self._options_widget.levels = initial_level
-        self._options_widget.update_viewer()
         self._update_data()
         return True
 
@@ -64,6 +59,7 @@ class GlueVispyViewer(DataViewer):
     def _update_data(self):
         self._vispy_widget.set_data(self._data)
         self._vispy_widget.add_volume_visual()
+        self._options_widget.update_viewer()
         self._redraw()
 
     def _update_subsets(self):

--- a/vispy_volume/glue_viewer.py
+++ b/vispy_volume/glue_viewer.py
@@ -5,7 +5,7 @@ from glue.core import message as msg
 
 # Add a __init__.py file to this folder can solve the relative import problem
 from .vispy_widget import QtVispyWidget
-# from .options_widget import VolumeOptionsWidget
+from .options_widget import VolumeOptionsWidget
 
 class GlueVispyViewer(DataViewer):
 
@@ -15,13 +15,13 @@ class GlueVispyViewer(DataViewer):
         super(GlueVispyViewer, self).__init__(session, parent=parent)
         self._vispy_widget = QtVispyWidget()
         self._canvas = self._vispy_widget.canvas
-        # self._canvas.size = (self.viewer_size[0], self.viewer_size[1])
-        self.viewer_size = self._canvas.size
+        self._canvas.size = self.viewer_size
+        # self.viewer_size = self._canvas.size
         # self._canvas.update()
         self.setCentralWidget(self._canvas.native)
         self._data = None
         self._subsets = []
-        # self._options_widget = VolumeOptionsWidget()
+        self._options_widget = VolumeOptionsWidget(vispy_widget=self._vispy_widget)
 
     def register_to_hub(self, hub):
 
@@ -44,9 +44,9 @@ class GlueVispyViewer(DataViewer):
 
     def add_data(self, data):
         self._data = data['PRIMARY']
-        # initial_level = "{0:.3g}".format(np.nanpercentile(data['PRIMARY'], 99))
-        # self._options_widget.levels = initial_level
-        # self._options_widget.update_viewer()
+        initial_level = "{0:.3g}".format(np.nanpercentile(data['PRIMARY'], 99))
+        self._options_widget.levels = initial_level
+        self._options_widget.update_viewer()
         self._update_data()
         return True
 
@@ -82,6 +82,6 @@ class GlueVispyViewer(DataViewer):
 
         return self._layer_view'''
 
-    # def options_widget(self):
-    #     return self._options_widget
+    def options_widget(self):
+        return self._options_widget
 

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -6,6 +6,8 @@ from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
 # from palettable.colorbrewer import COLOR_MAPS
 from vispy.color import Colormap, get_colormaps
+# from .mpl_widget import MplWidget, defer_draw
+
 
 __all__ = ["VolumeOptionsWidget"]
 
@@ -24,7 +26,7 @@ class VolumeOptionsWidget(QtGui.QWidget):
         for map_name in get_colormaps():
             self.ui.cmap_menu.addItem(map_name)
 
-        self.ui.apply.clicked.connect(self.update_viewer)
+        # self.ui.apply.clicked.connect(self.update_viewer)
 
         self._vispy_widget = vispy_widget
         # self.levels = []
@@ -46,6 +48,21 @@ class VolumeOptionsWidget(QtGui.QWidget):
         # self._vispy_widget.alpha = self.alpha
         # self._vispy_widget.levels = self.levels
         self._vispy_widget.translucent_cmap = self.cmap
+
+    '''@defer_draw
+    def _update_render_console(self, is_monochrome):
+        if is_monochrome:
+            self.ui.rgb_options.hide()
+            self.ui.mono_att_label.show()
+            self.ui.attributeComboBox.show()
+            self.client.rgb_mode(False)
+        else:
+            self.ui.mono_att_label.hide()
+            self.ui.attributeComboBox.hide()
+            self.ui.rgb_options.show()
+            rgb = self.client.rgb_mode(True)
+            if rgb is not None:
+                self.ui.rgb_options.artist = rgb'''
 
     '''@property
     def live(self):

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -1,0 +1,103 @@
+import os
+import six
+import numpy as np
+from glue.external.qt import QtGui
+from glue.qt.qtutil import load_ui
+from glue.qt import get_qapp
+# from palettable.colorbrewer import COLOR_MAPS
+from vispy.color import Colormap, get_colormaps
+
+__all__ = ["VolumeOptionsWidget"]
+
+# UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
+UI_MAIN = '/Users/penny/Works/glue-3d-viewer/vispy_volume/options_widget.ui'
+
+class VolumeOptionsWidget(QtGui.QWidget):
+
+    def __init__(self, parent=None, vispy_widget=None):
+
+        super(VolumeOptionsWidget, self).__init__(parent=parent)
+
+        self.ui = load_ui(UI_MAIN, self)
+        if self.ui is None:
+            return
+        for map_name in get_colormaps():
+            self.ui.cmap_menu.addItem(map_name)
+
+        self.ui.apply.clicked.connect(self.update_viewer)
+
+        self._vispy_widget = vispy_widget
+        # self.levels = []
+        # self.spectral_stretch = 1.
+        # self.alpha = 0.5
+
+        self.ui.cmap_menu.currentIndexChanged.connect(self.update_live)
+        # self.ui.alpha_slider.valueChanged.connect(self.update_live)
+        # self.ui.values_field.returnPressed.connect(self.update_live)
+        # self.ui.spectral_stretch_field.returnPressed.connect(self.update_live)
+
+    def update_live(self):
+        # if self.live:
+        self.update_viewer()
+
+    def update_viewer(self):
+        # self._vispy_widget.spectral_stretch = self.spectral_stretch
+        self._vispy_widget.opaque_cmap = self.cmap
+        # self._vispy_widget.alpha = self.alpha
+        # self._vispy_widget.levels = self.levels
+        self._vispy_widget.translucent_cmap = self.cmap
+
+    '''@property
+    def live(self):
+        return self.ui.live_checkbox.isChecked()
+
+    @property
+    def spectral_stretch(self):
+        return float(self.ui.spectral_stretch_field.text())
+
+    @spectral_stretch.setter
+    def spectral_stretch(self, spectral_stretch):
+        self.ui.spectral_stretch_field.setText("{0:g}".format(spectral_stretch))
+
+    @property
+    def alpha(self):
+        return self.ui.alpha_slider.value() / 100.
+
+    @alpha.setter
+    def alpha(self, value):
+        return self.ui.alpha_slider.setValue(value * 100.)'''
+
+    @property
+    def cmap(self):
+        return self.ui.cmap_menu.currentText()
+
+    @cmap.setter
+    def cmap(self, value):
+        index = self.ui.cmap_menu.fingText(value)
+        self.ui.cmap_menu.setCurrentIndex(index)
+
+    '''@property
+    def levels(self):
+        text = self.ui.values_field.text()
+        try:
+            return np.array(text.split(','), dtype=float)
+        except:
+            QtGui.QMessageBox.critical(self,
+                                       "Error", "Could not parse levels: {0}".format(text),
+                                       buttons=QtGui.QMessageBox.Ok)
+            return np.array([])
+
+    @levels.setter
+    def levels(self, levels):
+        if isinstance(levels, six.string_types):
+            self.ui.values_field.setText(levels)
+        else:
+            self.ui.values_field.setText(", ".join([str(x) for x in levels]))'''
+
+
+if __name__ == "__main__":
+    app = get_qapp()
+    d = VolumeOptionsWidget()
+    d.show()
+    app.exec_()
+    app.quit()

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -1,12 +1,8 @@
 import os
-import six
-import numpy as np
 from glue.external.qt import QtGui
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
-# from palettable.colorbrewer import COLOR_MAPS
-from vispy.color import Colormap, get_colormaps
-# from .mpl_widget import MplWidget, defer_draw
+from vispy.color import get_colormaps
 
 
 __all__ = ["VolumeOptionsWidget"]
@@ -26,63 +22,41 @@ class VolumeOptionsWidget(QtGui.QWidget):
         for map_name in get_colormaps():
             self.ui.cmap_menu.addItem(map_name)
 
-        # self.ui.apply.clicked.connect(self.update_viewer)
-
         self._vispy_widget = vispy_widget
-        # self.levels = []
-        # self.spectral_stretch = 1.
-        # self.alpha = 0.5
 
-        self.ui.cmap_menu.currentIndexChanged.connect(self.update_live)
-        # self.ui.alpha_slider.valueChanged.connect(self.update_live)
-        # self.ui.values_field.returnPressed.connect(self.update_live)
-        # self.ui.spectral_stretch_field.returnPressed.connect(self.update_live)
+        self.ui.threshold_lab.hide()
+        self.ui.threshold_slider.hide()
 
-    def update_live(self):
-        # if self.live:
-        self.update_viewer()
+        # UI control connect
+        self.ui.cmap_menu.currentIndexChanged.connect(self.update_viewer)
+        self.ui.threshold_slider.valueChanged.connect(self.update_threshold)
+        self.ui.vol_radio.toggled.connect(self._update_render_method)
+
+    def update_threshold(self):
+        self._vispy_widget.volume1.threshold = self.threshold
 
     def update_viewer(self):
-        # self._vispy_widget.spectral_stretch = self.spectral_stretch
-        self._vispy_widget.opaque_cmap = self.cmap
-        # self._vispy_widget.alpha = self.alpha
-        # self._vispy_widget.levels = self.levels
-        self._vispy_widget.translucent_cmap = self.cmap
+        self._vispy_widget.volume1.cmap = self.cmap
 
-    '''@defer_draw
-    def _update_render_console(self, is_monochrome):
-        if is_monochrome:
-            self.ui.rgb_options.hide()
-            self.ui.mono_att_label.show()
-            self.ui.attributeComboBox.show()
-            self.client.rgb_mode(False)
+
+    def _update_render_method(self, is_volren):
+        if is_volren:
+            self.ui.threshold_slider.hide()
+            self.ui.threshold_lab.hide()
+            self._vispy_widget.volume1.method = 'mip'
+
         else:
-            self.ui.mono_att_label.hide()
-            self.ui.attributeComboBox.hide()
-            self.ui.rgb_options.show()
-            rgb = self.client.rgb_mode(True)
-            if rgb is not None:
-                self.ui.rgb_options.artist = rgb'''
-
-    '''@property
-    def live(self):
-        return self.ui.live_checkbox.isChecked()
+            self.ui.threshold_slider.show()
+            self.ui.threshold_lab.show()
+            self._vispy_widget.volume1.method = 'iso'
 
     @property
-    def spectral_stretch(self):
-        return float(self.ui.spectral_stretch_field.text())
+    def threshold(self):
+        return self.ui.threshold_slider.value() / 100.
 
-    @spectral_stretch.setter
-    def spectral_stretch(self, spectral_stretch):
-        self.ui.spectral_stretch_field.setText("{0:g}".format(spectral_stretch))
-
-    @property
-    def alpha(self):
-        return self.ui.alpha_slider.value() / 100.
-
-    @alpha.setter
-    def alpha(self, value):
-        return self.ui.alpha_slider.setValue(value * 100.)'''
+    @threshold.setter
+    def threshold(self, value):
+        return self.ui.threshold_slider.setValue(value * 100.)
 
     @property
     def cmap(self):
@@ -92,24 +66,6 @@ class VolumeOptionsWidget(QtGui.QWidget):
     def cmap(self, value):
         index = self.ui.cmap_menu.fingText(value)
         self.ui.cmap_menu.setCurrentIndex(index)
-
-    '''@property
-    def levels(self):
-        text = self.ui.values_field.text()
-        try:
-            return np.array(text.split(','), dtype=float)
-        except:
-            QtGui.QMessageBox.critical(self,
-                                       "Error", "Could not parse levels: {0}".format(text),
-                                       buttons=QtGui.QMessageBox.Ok)
-            return np.array([])
-
-    @levels.setter
-    def levels(self, levels):
-        if isinstance(levels, six.string_types):
-            self.ui.values_field.setText(levels)
-        else:
-            self.ui.values_field.setText(", ".join([str(x) for x in levels]))'''
 
 
 if __name__ == "__main__":

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -11,8 +11,8 @@ from vispy.color import Colormap, get_colormaps
 
 __all__ = ["VolumeOptionsWidget"]
 
-# UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
-UI_MAIN = '/Users/penny/Works/glue-3d-viewer/vispy_volume/options_widget.ui'
+UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
+# UI_MAIN = '/Users/penny/Works/glue-3d-viewer/vispy_volume/options_widget.ui'
 
 class VolumeOptionsWidget(QtGui.QWidget):
 

--- a/vispy_volume/options_widget.ui
+++ b/vispy_volume/options_widget.ui
@@ -1,58 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>Widget</class>
+ <widget class="QWidget" name="Widget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>423</width>
-    <height>314</height>
+    <width>330</width>
+    <height>271</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>3D_Volume</string>
   </property>
-
-  <layout class="QGridLayout" name="gridLayout_2">
-
-   <item row="1" column="0">
-    <layout class="QGridLayout" name="gridLayout">
-     
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Colormap:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cmap_menu"/>
-     </item>
-     
-    </layout>
-   </item>
-
-
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>3D Volumn parameters</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-
-  </layout>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>311</width>
+     <height>111</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>3D Volume Methods:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="1" column="0">
+     <widget class="QRadioButton" name="radioButton_2">
+      <property name="text">
+       <string>Volume Rendering</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QRadioButton" name="radioButton">
+      <property name="text">
+       <string>Isosurface</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="vol_ren_widget" native="true">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>140</y>
+     <width>311</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>0</y>
+      <width>149</width>
+      <height>76</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Colormaps:</string>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="cmap_menu">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>30</y>
+      <width>171</width>
+      <height>26</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>40</y>
+      <width>95</width>
+      <height>76</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Threshold:</string>
+    </property>
+   </widget>
+   <widget class="QSlider" name="horizontalSlider">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>70</y>
+      <width>160</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="orientation">
+     <enum>Qt::Horizontal</enum>
+    </property>
+   </widget>
+  </widget>
  </widget>
+ <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections/>
 </ui>

--- a/vispy_volume/options_widget.ui
+++ b/vispy_volume/options_widget.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>423</width>
+    <height>314</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+
+  <layout class="QGridLayout" name="gridLayout_2">
+
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Colormap:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cmap_menu"/>
+     </item>
+     
+    </layout>
+   </item>
+
+
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>3D Volumn parameters</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/vispy_volume/options_widget.ui
+++ b/vispy_volume/options_widget.ui
@@ -35,7 +35,7 @@
      </layout>
     </item>
     <item row="1" column="0">
-     <widget class="QRadioButton" name="radioButton_2">
+     <widget class="QRadioButton" name="vol_radio">
       <property name="text">
        <string>Volume Rendering</string>
       </property>
@@ -45,7 +45,7 @@
      </widget>
     </item>
     <item row="1" column="1">
-     <widget class="QRadioButton" name="radioButton">
+     <widget class="QRadioButton" name="iso_radio">
       <property name="text">
        <string>Isosurface</string>
       </property>
@@ -62,7 +62,7 @@
      <height>91</height>
     </rect>
    </property>
-   <widget class="QLabel" name="label_3">
+   <widget class="QLabel" name="cmap_lab">
     <property name="geometry">
      <rect>
       <x>10</x>
@@ -85,7 +85,7 @@
      </rect>
     </property>
    </widget>
-   <widget class="QLabel" name="label_2">
+   <widget class="QLabel" name="threshold_lab">
     <property name="geometry">
      <rect>
       <x>10</x>
@@ -98,7 +98,7 @@
      <string>Threshold:</string>
     </property>
    </widget>
-   <widget class="QSlider" name="horizontalSlider">
+   <widget class="QSlider" name="threshold_slider">
     <property name="geometry">
      <rect>
       <x>100</x>

--- a/vispy_volume/tests/test_glue_viewer.py
+++ b/vispy_volume/tests/test_glue_viewer.py
@@ -1,0 +1,12 @@
+from glue.qt import get_qapp
+from ..glue_viewer import GlueVispyViewer
+from glue.config import qt_client
+
+def test_viewer():
+
+    # Make sure QApplication is started
+    get_qapp()
+
+    # v = GlueVispyViewer()
+
+    qt_client.add(GlueVispyViewer)

--- a/vispy_volume/vispy_widget.py
+++ b/vispy_volume/vispy_widget.py
@@ -1,10 +1,10 @@
-from __future__ import absolute_import, division, print_function
+# from __future__ import absolute_import, division, print_function
 import numpy as np
 from itertools import cycle
 
 from glue.external.qt import QtGui, QtCore
 from vispy import scene, app
-from vispy.color import get_colormaps
+from vispy.color import get_colormaps, get_colormap
 from .colormaps import TransFire, TransGrays
 
 __all__ = ['QtVispyWidget']
@@ -13,10 +13,12 @@ __all__ = ['QtVispyWidget']
 class QtVispyWidget(QtGui.QWidget):
 
     # Setup colormap iterators
-    opaque_cmaps = cycle(get_colormaps())
+    '''opaque_cmaps = cycle(get_colormaps())
     translucent_cmaps = cycle([TransFire(), TransGrays()])
     opaque_cmap = next(opaque_cmaps)
-    translucent_cmap = next(translucent_cmaps)
+    translucent_cmap = next(translucent_cmaps)'''
+    opaque_cmap = get_colormap('autumn')
+    translucent_cmap = get_colormap('autumn')
     result = 1
     zoom_size = 0
 
@@ -45,18 +47,12 @@ class QtVispyWidget(QtGui.QWidget):
 
         # Set up cameras
         self.cam1, self.cam2, self.cam3 = self.set_cam()
+        # self.cam_dist = 100 # Set a default value as 100
         self.view.camera = self.cam2  # Select turntable at firstate_texture=emulate_texture)
 
         # Connect events
         self.canvas.events.key_press.connect(self.on_key_press)
         self.canvas.events.mouse_wheel.connect(self.on_mouse_wheel)
-
-    '''def set_canvas_size(self, width, height):
-        if type(width)=='int':
-            self.canvas.size = (width, height)
-        else:
-            self.canvas.size = (400, 300)
-        self.canvas.update()'''
 
     def set_data(self, data):
         self.data = data
@@ -77,13 +73,18 @@ class QtVispyWidget(QtGui.QWidget):
         volume1 = scene.visuals.Volume(vol1, parent=self.view.scene, threshold=0.1,
                                        emulate_texture=self.emulate_texture)
         trans = (-vol1.shape[2]/2, -vol1.shape[1]/2, -vol1.shape[0]/2)
+        axis_scale = (vol1.shape[2], vol1.shape[1], vol1.shape[0])
         volume1.transform = scene.STTransform(translate=trans)
+        self.axis.transform = scene.STTransform(translate=trans, scale=axis_scale)
+        # self.cam_dist = vol1.shape[1]
+        self.cam2.distance = self.cam3.distance = vol1.shape[1]
+        # self.cam2.center = (-vol1.shape[2]/2, -vol1.shape[1]/2, -vol1.shape[0]/2)
         self.volume1 = volume1
 
     def add_text_visual(self):
         # Create the text visual to show zoom scale
-        text = scene.visuals.Text('', parent=self.canvas.scene, color='white', bold=True, font_size=20)
-        text.pos = self.canvas.size[0]-80, 80
+        text = scene.visuals.Text('', parent=self.canvas.scene, color='white', bold=True, font_size=16)
+        text.pos = 60, 60
         return text
 
     def on_timer(self, event):
@@ -93,7 +94,24 @@ class QtVispyWidget(QtGui.QWidget):
     def set_cam(self):
         # Create two cameras (1 for firstperson, 3 for 3d person)
         fov = 60.
+        '''
+        The fly camera provides a way to explore 3D data using an interaction style that resembles a flight simulator.
+        Moving:
+
+        * arrow keys, or WASD to move forward, backward, left and right
+        * F and C keys move up and down
+        * Space bar to brake
+
+        Viewing:
+
+        * Use the mouse while holding down LMB to control the pitch and yaw.
+        * Alternatively, the pitch and yaw can be changed using the keys
+            IKJL
+        * The camera auto-rotates to make the bottom point down, manual
+            rolling can be performed using Q and E.'''
         cam1 = scene.cameras.FlyCamera(parent=self.view.scene, fov=fov, name='Fly')
+
+        # 3D camera class that orbits around a center point while maintaining a view on a center point.
         cam2 = scene.cameras.TurntableCamera(parent=self.view.scene, fov=fov,
                                             name='Turntable')
         cam3 = scene.cameras.ArcballCamera(parent=self.view.scene, fov=fov, name='Arcball')
@@ -104,7 +122,6 @@ class QtVispyWidget(QtGui.QWidget):
         self.zoom_text.text = 'X %s' % round(self.zoom_size, 1)
         self.zoom_text.show = True
         self.zoom_timer.start(interval=0.2, iterations=8)
-
 
     # @canvas.events.key_press.connect
     def on_key_press(self, event):
@@ -127,12 +144,12 @@ class QtVispyWidget(QtGui.QWidget):
             self.volume1.visible = not self.volume1.visible
 
         # Color scheme cannot work now
-        elif event.text == '4':
-            if self.volume1.method in ['mip', 'iso']:
-                cmap = self.opaque_cmap = next(self.opaque_cmaps)
-            else:
-                cmap = self.translucent_cmap = next(self.translucent_cmaps)
-            self.volume1.cmap = cmap
+        # elif event.text == '4':
+        #     if self.volume1.method in ['mip', 'iso']:
+        #         cmap = self.opaque_cmap = next(self.opaque_cmaps)
+        #     else:
+        #         cmap = self.translucent_cmap  = next(self.translucent_cmaps)
+        #     self.volume1.cmap = cmap
 
         elif event.text == '0':
             self.cam1.set_range()


### PR DESCRIPTION
Works have been done:
- Add a simple side panel for Vispy Viewer with two rendering methods : `volume rendering` and `IsoSurface` with `colormap` selection and `threshold` control (only for isosurface rendering).
- Fix some errors of axis, cameras and canvas scale.

I planned to transferred keypress functionalities, including camera view switch, colormap selection & rendering methods toggle (these two have been realized in this simple panel already) and others, into a more understandable style in the `side panel & toolbar`. 

Any advice on the design of these two parts?Thanks a lot :)
