### PR TITLE
Add an extra viewbox for Isosurface

### DIFF
--- a/vispy_volume/glue_viewer.py
+++ b/vispy_volume/glue_viewer.py
@@ -14,7 +14,7 @@ class GlueVispyViewer(DataViewer):
         super(GlueVispyViewer, self).__init__(session, parent=parent)
         self._vispy_widget = QtVispyWidget()
         self._canvas = self._vispy_widget.canvas
-        self._canvas.size = self.viewer_size
+        self._canvas.size = self.viewer_size = (600, 300)
         self.setCentralWidget(self._canvas.native)
 
         self._data = None

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -3,6 +3,7 @@ from glue.external.qt import QtGui
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
 from vispy.color import get_colormaps
+from vispy import scene
 
 
 __all__ = ["VolumeOptionsWidget"]
@@ -22,22 +23,46 @@ class VolumeOptionsWidget(QtGui.QWidget):
         for map_name in get_colormaps():
             self.ui.cmap_menu.addItem(map_name)
 
+        for vol_name in ['RA', 'DEC', 'VEL']:
+            self.ui.stretch_menu.addItem(vol_name)
+
+        # Set up default values for side panel
         self._vispy_widget = vispy_widget
+        self._stretch_scale = [1, 1, 1]
+
+        # self._axis_scale = None
+        self.threshold = 0
+        self.stretch_slider_value = 0
+        self.cmap = 'hsl'
+        self.stretch_menu_item = 'RA'
 
         self.ui.threshold_lab.hide()
         self.ui.threshold_slider.hide()
 
         # UI control connect
-        self.ui.cmap_menu.currentIndexChanged.connect(self.update_viewer)
-        self.ui.threshold_slider.valueChanged.connect(self.update_threshold)
+        self.ui.stretch_menu.currentIndexChanged.connect(self.update_stretch_menu)
+        self.ui.stretch_slider.valueChanged.connect(self.update_stretch_slider)
         self.ui.vol_radio.toggled.connect(self._update_render_method)
 
-    def update_threshold(self):
-        self._vispy_widget.volume1.threshold = self.threshold
+        self.ui.cmap_menu.currentIndexChanged.connect(self.update_viewer)
+        self.ui.threshold_slider.valueChanged.connect(self.update_viewer)
+
+    def update_stretch_menu(self):
+        self.stretch_slider_value = 0
+        self._stretch_scale = [1, 1, 1]
+        self.update_viewer()
+
+    def update_stretch_slider(self):
+        _index = self.ui.stretch_menu.currentIndex()
+        self._stretch_scale[_index] = self.stretch_slider_value+1
+        # _new_axis_scale = self._vispy_widget.widget_axis_scale[_index] + self.stretch_slider_value
+        # self._vispy_widget.axis.transform.scale = _new_axis_scale
+        self.update_viewer()
 
     def update_viewer(self):
         self._vispy_widget.volume1.cmap = self.cmap
-
+        self._vispy_widget.volume1.transform.scale = self._stretch_scale
+        self._vispy_widget.volume1.threshold = self.threshold
 
     def _update_render_method(self, is_volren):
         if is_volren:
@@ -50,6 +75,9 @@ class VolumeOptionsWidget(QtGui.QWidget):
             self.ui.threshold_lab.show()
             self._vispy_widget.volume1.method = 'iso'
 
+        # May need a initiation for _strech_scale here
+
+
     @property
     def threshold(self):
         return self.ui.threshold_slider.value() / 100.
@@ -59,12 +87,29 @@ class VolumeOptionsWidget(QtGui.QWidget):
         return self.ui.threshold_slider.setValue(value * 100.)
 
     @property
+    def stretch_slider_value(self):
+        return self.ui.stretch_slider.value() / 10.
+
+    @stretch_slider_value.setter
+    def stretch_slider_value(self, value):
+        return self.ui.stretch_slider.setValue(value * 10. )
+
+    @property
+    def stretch_menu_item(self):
+        return self.ui.stretch_menu.currentText()
+
+    @stretch_menu_item.setter
+    def stretch_menu_item(self, value):
+        index = self.ui.stretch_menu.findText(value)
+        self.ui.stretch_menu.setCurrentIndex(index)
+
+    @property
     def cmap(self):
         return self.ui.cmap_menu.currentText()
 
     @cmap.setter
     def cmap(self, value):
-        index = self.ui.cmap_menu.fingText(value)
+        index = self.ui.cmap_menu.findText(value)
         self.ui.cmap_menu.setCurrentIndex(index)
 
 

--- a/vispy_volume/options_widget.py
+++ b/vispy_volume/options_widget.py
@@ -2,7 +2,8 @@ import os
 from glue.external.qt import QtGui
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
-from vispy.color import get_colormaps
+from vispy.color import get_colormaps, get_colormap
+from vispy import color
 from vispy import scene
 
 
@@ -55,36 +56,42 @@ class VolumeOptionsWidget(QtGui.QWidget):
     def update_stretch_slider(self):
         _index = self.ui.stretch_menu.currentIndex()
         self._stretch_scale[_index] = self.stretch_slider_value+1
-        # _new_axis_scale = self._vispy_widget.widget_axis_scale[_index] + self.stretch_slider_value
-        # self._vispy_widget.axis.transform.scale = _new_axis_scale
         self.update_viewer()
 
     def update_viewer(self):
         self._vispy_widget.volume1.cmap = self.cmap
         self._vispy_widget.volume1.transform.scale = self._stretch_scale
-        self._vispy_widget.volume1.threshold = self.threshold
+        # self._vispy_widget.volume1.threshold = self.threshold
+
+        # TODO: a cmap for isosurface shoud be added, just do a trick here
+        _iso_color = get_colormap(self.cmap).colors[0]
+        _iso_color.alpha = 0.3
+        self._vispy_widget.iso1._color = color.Color(_iso_color)
+        self._vispy_widget.iso1.level = self.threshold
+        self._vispy_widget.iso1.transform.scale = self._stretch_scale
 
     def _update_render_method(self, is_volren):
         if is_volren:
             self.ui.threshold_slider.hide()
             self.ui.threshold_lab.hide()
-            self._vispy_widget.volume1.method = 'mip'
+            # self._vispy_widget.volume1.method = 'mip'
 
         else:
+            self.ui.threshold = 0
             self.ui.threshold_slider.show()
             self.ui.threshold_lab.show()
-            self._vispy_widget.volume1.method = 'iso'
+            # self._vispy_widget.volume1.method = 'iso'
 
         # May need a initiation for _strech_scale here
 
-
+    # The value limitation is 0~99
     @property
     def threshold(self):
-        return self.ui.threshold_slider.value() / 100.
+        return self.ui.threshold_slider.value() / 20.
 
     @threshold.setter
     def threshold(self, value):
-        return self.ui.threshold_slider.setValue(value * 100.)
+        return self.ui.threshold_slider.setValue(value * 20.)
 
     @property
     def stretch_slider_value(self):

--- a/vispy_volume/options_widget.ui
+++ b/vispy_volume/options_widget.ui
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>10</y>
+     <y>0</y>
      <width>311</width>
      <height>61</height>
     </rect>
@@ -57,9 +57,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>100</y>
-     <width>291</width>
-     <height>141</height>
+     <y>60</y>
+     <width>281</width>
+     <height>114</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_3">
@@ -140,11 +140,15 @@
       </item>
      </layout>
     </item>
+    <item row="2" column="0">
+     <widget class="Line" name="line">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
-  <zorder>gridLayoutWidget</zorder>
-  <zorder>gridLayoutWidget_2</zorder>
-  <zorder>horizontalLayoutWidget</zorder>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>

--- a/vispy_volume/options_widget.ui
+++ b/vispy_volume/options_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>330</width>
-    <height>271</height>
+    <width>334</width>
+    <height>284</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>10</x>
      <y>10</y>
      <width>311</width>
-     <height>111</height>
+     <height>61</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -53,65 +53,98 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="vol_ren_widget" native="true">
+  <widget class="QWidget" name="gridLayoutWidget_2">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>140</y>
-     <width>311</width>
-     <height>91</height>
+     <y>100</y>
+     <width>291</width>
+     <height>141</height>
     </rect>
    </property>
-   <widget class="QLabel" name="cmap_lab">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>0</y>
-      <width>149</width>
-      <height>76</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Colormaps:</string>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="cmap_menu">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>30</y>
-      <width>171</width>
-      <height>26</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QLabel" name="threshold_lab">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>40</y>
-      <width>95</width>
-      <height>76</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Threshold:</string>
-    </property>
-   </widget>
-   <widget class="QSlider" name="threshold_slider">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>70</y>
-      <width>160</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="orientation">
-     <enum>Qt::Horizontal</enum>
-    </property>
-   </widget>
+   <layout class="QGridLayout" name="gridLayout_3">
+    <item row="5" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <item>
+       <widget class="QLabel" name="threshold_lab">
+        <property name="text">
+         <string>Threshold:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="threshold_slider">
+        <property name="minimumSize">
+         <size>
+          <width>238</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+       <widget class="QLabel" name="cmap_lab">
+        <property name="text">
+         <string>Colormaps:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cmap_menu"/>
+      </item>
+     </layout>
+    </item>
+    <item row="1" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QLabel" name="stretch_lab">
+        <property name="text">
+         <string>Stretch:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="stretch_menu"/>
+      </item>
+      <item>
+       <widget class="QSlider" name="stretch_slider">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="tracking">
+         <bool>true</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::NoTicks</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
   </widget>
+  <zorder>gridLayoutWidget</zorder>
+  <zorder>gridLayoutWidget_2</zorder>
+  <zorder>horizontalLayoutWidget</zorder>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>

--- a/vispy_volume/vispy_widget.py
+++ b/vispy_volume/vispy_widget.py
@@ -33,6 +33,8 @@ class QtVispyWidget(QtGui.QWidget):
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
 
+        self.widget_axis_scale = [1, 1, 1]
+
         # Set up cameras
         self.cam1, self.cam2, self.cam3 = self.set_cam()
         # self.cam_dist = 100 # Set a default value as 100
@@ -66,13 +68,15 @@ class QtVispyWidget(QtGui.QWidget):
         volume1.cmap = self.color_map
 
         trans = (-vol1.shape[2]/2, -vol1.shape[1]/2, -vol1.shape[0]/2)
-        axis_scale = (vol1.shape[2], vol1.shape[1], vol1.shape[0])
+        _axis_scale = (vol1.shape[2], vol1.shape[1], vol1.shape[0])
         volume1.transform = scene.STTransform(translate=trans)
 
-        self.axis.transform = scene.STTransform(translate=trans, scale=axis_scale)
+        self.axis.transform = scene.STTransform(translate=trans, scale=_axis_scale)
         self.cam2.distance = self.cam3.distance = vol1.shape[1]
 
         self.volume1 = volume1
+        self.widget_axis_scale = self.axis.transform.scale
+
 
     def add_text_visual(self):
         # Create the text visual to show zoom scale

--- a/vispy_volume/vispy_widget.py
+++ b/vispy_volume/vispy_widget.py
@@ -16,29 +16,39 @@ class QtVispyWidget(QtGui.QWidget):
         self.canvas = scene.SceneCanvas(keys='interactive', show=True)
         self.canvas.measure_fps()
 
+        self.grid = self.canvas.central_widget.add_grid()
+
         # Set up a viewbox to display the image with interactive pan/zoom
-        self.view = self.canvas.central_widget.add_view()
+
+        self.view = self.grid.add_view(name='vb1')
         self.view.border_color = 'red'
         self.view.parent = self.canvas.scene
+
+        self.view2 = self.grid.add_view(name='vb1')
+        self.view2.border_color = 'red'
+        self.view2.parent = self.canvas.scene
+
 
         # Set whether we are emulating a 3D texture
         self.emulate_texture = False
 
         self.data = None
         self.volume1 = None
+        self.iso1 = None
         self.zoom_size = 0
         self.zoom_text = self.add_text_visual()
         self.zoom_timer = app.Timer(0.2, connect=self.on_timer, start=False)
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
+        self.axis2 = scene.visuals.XYZAxis(parent=self.view2.scene)
 
         self.widget_axis_scale = [1, 1, 1]
 
         # Set up cameras
         self.cam1, self.cam2, self.cam3 = self.set_cam()
         # self.cam_dist = 100 # Set a default value as 100
-        self.view.camera = self.cam2  # Select turntable at firstate_texture=emulate_texture)
+        self.view.camera = self.view2.camera = self.cam2  # Select turntable at firstate_texture=emulate_texture)
 
         # Set up default colormap
         self.color_map = get_colormap('autumn')
@@ -67,14 +77,23 @@ class QtVispyWidget(QtGui.QWidget):
                                        emulate_texture=self.emulate_texture)
         volume1.cmap = self.color_map
 
+        # Create the isosurface visual and give default settings
+        # vol_rotate = [vol1[0], vol1[1], vol1[2]]
+        # vol2 = vol1.reshape((vol1.shape[2], vol1.shape[1], vol1.shape[0]))
+        iso1 = scene.visuals.Isosurface(vol1, color=(0.5, 0.5, 1, 0.6), level=vol1.mean()*5, parent=self.view2.scene)
+
         trans = (-vol1.shape[2]/2, -vol1.shape[1]/2, -vol1.shape[0]/2)
         _axis_scale = (vol1.shape[2], vol1.shape[1], vol1.shape[0])
-        volume1.transform = scene.STTransform(translate=trans)
 
-        self.axis.transform = scene.STTransform(translate=trans, scale=_axis_scale)
+        volume1.transform = scene.STTransform(translate=trans)
+        # iso1.transform = scene.AffineTransform(rotate=(90,(1,0,0)), translate=trans)
+        iso1.transform = scene.STTransform(translate=trans)
+
+        self.axis.transform = self.axis2.transform = scene.STTransform(translate=trans, scale=_axis_scale)
         self.cam2.distance = self.cam3.distance = vol1.shape[1]
 
         self.volume1 = volume1
+        self.iso1 = iso1
         self.widget_axis_scale = self.axis.transform.scale
 
 
@@ -117,7 +136,6 @@ class QtVispyWidget(QtGui.QWidget):
     def on_mouse_wheel(self, event):
         self.zoom_size += event.delta[1]
         self.zoom_text.text = 'X %s' % round(self.zoom_size, 1)
-        self.zoom_text.show = True
         self.zoom_timer.start(interval=0.2, iterations=8)
 
     # @canvas.events.key_press.connect


### PR DESCRIPTION
I tried to optimize the Isosurface rendering performance in the `Volume Visual` but failed to remove those 'strange' background & change the transparency. So I created a new `Isosurface Visual` to another Viewbox and set the same camera as the `3D Volume Viewbox`.  (These two visuals are totally different and you can get more information from VisPy Document)

This pull request could be **closed** first that there are still some bugs in it (such as the different data loading scheme of two visuals and a new colormap for the `Isosurface` visual). I created it here because I hope to get some advice from you before start to deal with those bugs. Is it ok to add another viewbox to display the Isosurface or any other better ways to do it? 
