### PR TITLE
Strange glitch when starting up the volume rendering viewer

### DIFF
--- a/vispy_isosurface/iso_vispyWidget.py
+++ b/vispy_isosurface/iso_vispyWidget.py
@@ -13,7 +13,7 @@ class QtVispyIsoWidget(QtGui.QWidget):
         super(QtVispyIsoWidget, self).__init__(parent=parent)
 
         # Prepare canvas
-        self.canvas = scene.SceneCanvas(keys='interactive', show=True)
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
         self.canvas.measure_fps()
 
         # Set up a viewbox to display the image with interactive pan/zoom

--- a/vispy_volume/vol_vispyWidget.py
+++ b/vispy_volume/vol_vispyWidget.py
@@ -13,7 +13,7 @@ class QtVispyWidget(QtGui.QWidget):
         super(QtVispyWidget, self).__init__(parent=parent)
 
         # Prepare canvas
-        self.canvas = scene.SceneCanvas(keys='interactive', show=True)
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
         self.canvas.measure_fps()
 
         # Set up a viewbox to display the image with interactive pan/zoom


### PR DESCRIPTION
When starting up the 3D viewer, it first appears outside the glue window, then inside:

![screenflow](https://cloud.githubusercontent.com/assets/314716/9830940/e082aeac-5942-11e5-8e5f-59364936c827.gif)

I'm not yet sure what this is due to, but I think it could happen if we draw the VisPy content before the widget is shown.
