### PR TITLE
hightlight subset

### DIFF
--- a/glue_vispy_viewers/volume/vol_glue_viewer.py
+++ b/glue_vispy_viewers/volume/vol_glue_viewer.py
@@ -71,6 +71,7 @@ class GlueVispyViewer(DataViewer):
     def _remove_subset(self, message):
         self._subsets.remove(message.subset)
         self._update_subsets()
+        self._vispy_widget.vol_visual.visible = True
 
     def _update_data(self):
         self._vispy_widget.data = self.data

--- a/glue_vispy_viewers/volume/vol_vispy_widget.py
+++ b/glue_vispy_viewers/volume/vol_vispy_widget.py
@@ -34,7 +34,9 @@ class QtVispyWidget(QtGui.QWidget):
         self._current_array = None
 
         self.vol_visual = None
-        self.subvol_visual = None
+        self.sub_vol_visual = None
+        self.subsets = None
+
         self.zoom_size = 0
         self.zoom_text_visual = self.add_text_visual()
         self.zoom_timer = app.Timer(0.2, connect=self.on_timer, start=False)
@@ -135,14 +137,14 @@ class QtVispyWidget(QtGui.QWidget):
     def update_volume_visual(self):
         # TODO: implement mask here
         for s in self.subsets:
-            # I think the mask array here is not as the same shape as the data, it would be smaller shape...
             if s['mask'].size == self.component.size:
                 vol_data = np.nan_to_num(self.component)
+
                 _mask = (np.logical_and(vol_data, s['mask'])).astype(int)
                 _mask_data = _mask * self.component
                 print(scene.visuals)
                 print(dir(self.vol_visual))
-                self.subvol_visual.set_data(_mask_data)
+                self.sub_vol_visual.set_data(_mask_data)
                 self.vol_visual.visible = False
 
     def add_volume_visual(self):
@@ -172,14 +174,14 @@ class QtVispyWidget(QtGui.QWidget):
         self.widget_axis_scale = self.axis.transform.scale
 
         # Add the sub-volume visual
-        subvol_visual = scene.visuals.Volume(np.zeros(vol_data.shape),
+        sub_vol_visual = scene.visuals.Volume(np.zeros(vol_data.shape),
                                           clim=(float(self.options_widget.cmin),
                                                 float(self.options_widget.cmax)),
                                           parent=self.view.scene, threshold=0.3, cmap='hot', method='mip',
                                           emulate_texture=self.emulate_texture)
 
-        subvol_visual.transform = scene.STTransform(translate=trans)
-        self.subvol_visual = subvol_visual
+        sub_vol_visual.transform = scene.STTransform(translate=trans)
+        self.sub_vol_visual = sub_vol_visual
 
     def add_text_visual(self):
         # Create the text visual to show zoom scale

--- a/glue_vispy_viewers/volume/vol_vispy_widget.py
+++ b/glue_vispy_viewers/volume/vol_vispy_widget.py
@@ -129,6 +129,36 @@ class QtVispyWidget(QtGui.QWidget):
 
     def set_subsets(self, subsets):
         self.subsets = subsets
+        self.update_volume_visual()
+
+    def update_volume_visual(self):
+        # TODO: implement mask here
+        for s in self.subsets:
+            # _new_mask = s['mask'].reshape(self.component.shape)
+            _new_shape = (self.component.shape[2], self.component.shape[1], self.component.shape[0])
+            # I think the mask array here is not as the same shape as the data, it would be smaller shape...
+            if s['mask'].size == self.component.size:
+                # _new_mask = s['mask'].reshape(self.component.shape)
+                # _mask_data = self.component[_new_mask]
+                vol_data = np.nan_to_num(self.component)
+                _mask = (np.logical_and(vol_data, s['mask'])).astype(int)
+                # _mask = np.logical_and(self.component, s['mask']).astype(int)
+                # _mask_data = np.einsum('ij,jkl->ikl', _mask, self.component)
+                _mask_data = _mask * self.component
+                print(_mask[1][1])
+                print(_mask_data[1][1])
+                print(self.component[1][1])
+                print('s.size = %d, component.size = %d, newmask.size = %d' % (s['mask'].size, self.component.size, _mask_data.size))
+                print('mask_data shape:', _mask_data.shape)
+                print('component shape:', self.component.shape)
+
+                subset_visual = scene.visuals.Volume(_mask_data,
+                                                     clim=(float(self.options_widget.cmin),
+                                                           float(self.options_widget.cmax)),
+                                                     parent=self.view.scene, cmap='fire', method='mip',
+                                                     emulate_texture=self.emulate_texture)
+                subset_visual.transform = self.vol_visual.transform
+                self.vol_visual.visible = False
 
     def add_volume_visual(self):
 


### PR DESCRIPTION
This might not be a real pull request, some more work will be done before merging it.

Maxwell and I tried some methods to display the selected dataset and we found that a simple & efficient solution now would be creating one volume visual for selected dataset as well as making the whole data volume invisible when displaying the selected part. Here is the highlight result (selected from Image Viewer and Histogram Viewer respectively ):

![image](https://cloud.githubusercontent.com/assets/13411839/10612142/8f40290e-771d-11e5-8d9b-aa81f8a6b517.png)

![image](https://cloud.githubusercontent.com/assets/13411839/10612755/3200ee42-7720-11e5-9f5f-1e5aa18b3f87.png)

Here are some questions about continuous work:
- Do we need to add one visual volume for each selected dataset or just use one visual to show all selected datasets through setting different data for it? Now only one selection works because I just want to try if the highlight works or not.
- Layers haven't been created now, maybe we should consider to implement it?
- Should the 'Plot Options' of the 3D Rendering Viewer also work on the subset part? It doesn't work now but I could try to implement it if necessary.
