### PR TITLE
3D Scatter Plot Viewer in Glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 
 env:
   matrix:
-   # - PYTHON_VERSION=2.7
+    - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.4
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 
 env:
   matrix:
-    - PYTHON_VERSION=2.7
+   # - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.4
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Experimental Glue VisPy plugin
 ==============================
 
-[![Build Status](https://travis-ci.org/glue-viz/glue-3d-viewer.svg)](https://travis-ci.org/glue-viz/glue-3d-viewer?branch=master)
+[![Build Status](https://travis-ci.org/PennyQ/glue-3d-viewer.svg)](https://travis-ci.org/PennyQ/glue-3d-viewer?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/1gov2vtuesjnij69/branch/master?svg=true)](https://ci.appveyor.com/project/astrofrog/glue-3d-viewer/branch/master)
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Experimental Glue VisPy plugin
 [![Build Status](https://travis-ci.org/PennyQ/glue-3d-viewer.svg)](https://travis-ci.org/PennyQ/glue-3d-viewer?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/nc4ernogomn164m6?svg=true)](https://ci.appveyor.com/project/PennyQ/glue-3d-viewer)
 
-https://ci.appveyor.com/api/github/webhook?id=nc4ernogomn164m6
-
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@ Experimental Glue VisPy plugin
 ==============================
 
 [![Build Status](https://travis-ci.org/PennyQ/glue-3d-viewer.svg)](https://travis-ci.org/PennyQ/glue-3d-viewer?branch=master)
-[![Build status](https://ci.appveyor.com/api/projects/status/1gov2vtuesjnij69/branch/master?svg=true)](https://ci.appveyor.com/project/astrofrog/glue-3d-viewer/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/nc4ernogomn164m6?svg=true)](https://ci.appveyor.com/project/PennyQ/glue-3d-viewer)
+
+https://ci.appveyor.com/api/github/webhook?id=nc4ernogomn164m6
+
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Experimental Glue VisPy plugin
 ==============================
 
-[![Build Status](https://travis-ci.org/PennyQ/glue-3d-viewer.svg)](https://travis-ci.org/PennyQ/glue-3d-viewer?branch=master)
-[![Build status](https://ci.appveyor.com/api/projects/status/nc4ernogomn164m6?svg=true)](https://ci.appveyor.com/project/PennyQ/glue-3d-viewer)
+[![Build Status](https://travis-ci.org/glue-viz/glue-3d-viewer.svg)](https://travis-ci.org/glue-viz/glue-3d-viewer?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/1gov2vtuesjnij69/branch/master?svg=true)](https://ci.appveyor.com/project/astrofrog/glue-3d-viewer/branch/master)
 
 
 Requirements

--- a/glue_vispy_viewers/scatter/__init__.py
+++ b/glue_vispy_viewers/scatter/__init__.py
@@ -1,0 +1,7 @@
+__author__ = 'penny'
+
+
+def setup():
+    from .scat_vispy_viewer import ScatVispyViewer
+    from glue.config import qt_client
+    qt_client.add(ScatVispyViewer)

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -15,6 +15,9 @@ UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
 
 class ScatOptionsWidget(QtGui.QWidget):
 
+    cmin = TextProperty('ui.clim_min')
+    cmax = TextProperty('ui.clim_max')
+
     def __init__(self, parent=None, vispy_widget=None):
 
         super(ScatOptionsWidget, self).__init__(parent=parent)
@@ -36,19 +39,33 @@ class ScatOptionsWidget(QtGui.QWidget):
     def _connect(self):
         ui = self.ui
 
-        ui.axis_apply.clicked.connect(self._refresh_program)
+        ui.axis_apply.clicked.connect(self._apply)
         ui.reset_button.clicked.connect(self._reset_view)
+        ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
+        ui.clim_min.returnPressed.connect(self._draw_clim)
+        ui.clim_max.returnPressed.connect(self._draw_clim)
 
     def set_valid_components(self, components):
         self.ui.xAxisComboBox.clear()
         self.ui.yAxisComboBox.clear()
         self.ui.zAxisComboBox.clear()
         self.ui.SizeComboBox.clear()
+        self.ui.ClimComboBox.clear()
         for component in components:
             self.ui.xAxisComboBox.addItem(component, component)
             self.ui.yAxisComboBox.addItem(component, component)
             self.ui.zAxisComboBox.addItem(component, component)
             self.ui.SizeComboBox.addItem(component, component)
+            self.ui.ClimComboBox.addItem(component, component)
+
+    def _clim_change(self):
+        if self._vispy_widget is not None:
+            self._vispy_widget._update_clim()
+
+    def _draw_clim(self):
+        return
+        # Pick the dataset between the threshold and draw them in different symbol
+        # Add another visual into it?
 
     def _apply(self):
         self._reset_clim()
@@ -59,12 +76,8 @@ class ScatOptionsWidget(QtGui.QWidget):
         self._refresh_viewer()
 
     def _reset_clim(self):
-        self.xmin = 'auto'
-        self.xmax = 'auto'
-        self.ymin = 'auto'
-        self.ymax = 'auto'
-        self.zmin = 'auto'
-        self.zmax = 'auto'
+        self.cmin = 'auto'
+        self.cmax = 'auto'
 
     # TODO: self._vispy_widget._refresh() is empty now
     def _refresh_viewer(self):

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -48,6 +48,8 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.color_view.setScene(self.color_scene)
         self.color_view.show()
 
+        self.true_color = self.color
+
         self._connect()
 
     # From 2D scatter
@@ -62,6 +64,14 @@ class ScatOptionsWidget(QtGui.QWidget):
 
         ui.clim_min.returnPressed.connect(self._draw_clim)
         ui.clim_max.returnPressed.connect(self._draw_clim)
+        ui.advanceButton.clicked.connect(self._color_picker_show)
+
+    def _color_picker_show(self):
+        color = QtGui.QColorDialog.getColor()
+        self.true_color = color.name()
+        self.color_view.setScene(self.color_scene)
+        self.color_view.setBackgroundBrush(QtGui.QColor(self.true_color))
+        self.color_view.show()
 
     def set_valid_components(self, components):
         self.ui.xAxisComboBox.clear()
@@ -102,6 +112,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.color_view.setScene(self.color_scene)
         self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
         self.color_view.show()
+        self.true_color = self.color
 
         # self._refresh_program()
 

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -50,7 +50,6 @@ class ScatOptionsWidget(QtGui.QWidget):
             self._update_labels_from_sliders(idx)
 
         # Constrain size of slider value boxes
-
         for slider_value in self.slider_values:
             slider_value.setMaximumWidth(60)
             slider_value.setFixedWidth(60)
@@ -60,7 +59,6 @@ class ScatOptionsWidget(QtGui.QWidget):
             self.ui.ColorComboBox.addItem(map_name, map_name)
 
         # Add a color display area here
-        # self.opacity = self.ui.opacity.value()
         self.color_view = self.ui.graphicsView
         self.color_scene = QtGui.QGraphicsScene()
         self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
@@ -71,34 +69,24 @@ class ScatOptionsWidget(QtGui.QWidget):
 
         self._connect()
 
-    # From 2D scatter
     def _connect(self):
         self.ui.axis_apply.clicked.connect(self._apply)
         self.ui.reset_button.clicked.connect(self._apply)
-        self.ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
-        self.ui.ColorComboBox.currentIndexChanged.connect(self._color_changed)
+        self.ui.ClimComboBox.currentIndexChanged.connect(self._clim_combo_change)
+        self.ui.ColorComboBox.currentIndexChanged.connect(self._color_change)
         self.ui.OpacitySlider.valueChanged.connect(self._refresh_viewer)
-        # self.ui.sizeSlider.valueChanged.connect(self._refresh_program)
 
-        self.ui.clim_min.returnPressed.connect(self._draw_clim)
-        self.ui.clim_max.returnPressed.connect(self._draw_clim)
+        self.ui.clim_min.returnPressed.connect(self._apply_clim)
+        self.ui.clim_max.returnPressed.connect(self._apply_clim)
         self.ui.advanceButton.clicked.connect(self._color_picker_show)
 
-        # Connect slider and values both wways
+        # Connect slider and values both ways
         from functools import partial
         for idx in range(4):
-
             self.stretch_sliders[idx].valueChanged.connect(partial(self._update_labels_from_sliders, idx))
             self.stretch_sliders[idx].valueChanged.connect(self._refresh_viewer)
 
             self.slider_values[idx].returnPressed.connect(partial(self._update_sliders_from_labels, idx))
-
-    def _color_picker_show(self):
-        color = QtGui.QColorDialog.getColor()
-        self.true_color = color.name()
-        self.color_view.setScene(self.color_scene)
-        self.color_view.setBackgroundBrush(QtGui.QColor(self.true_color))
-        self.color_view.show()
 
     def set_valid_components(self, components):
         self.ui.xAxisComboBox.clear()
@@ -113,17 +101,22 @@ class ScatOptionsWidget(QtGui.QWidget):
             self.ui.SizeComboBox.addItem(component, component)
             self.ui.ClimComboBox.addItem(component, component)
 
-    def _clim_change(self):
-        if self._vispy_widget is not None:
-            self._vispy_widget._update_clim()
+    def _reset_clim(self):
+        self.cmin = 'auto'
+        self.cmax = 'auto'
 
-    def _draw_clim(self):
-        # Pick the dataset between the threshold and draw them in different symbol
-        # Add another visual into it?
+    def _clim_combo_change(self):
+        if self._vispy_widget is not None:
+            self._vispy_widget.update_clim()
+
+    def _apply_clim(self):
         if self._vispy_widget is not None:
             self._vispy_widget.apply_clim()
 
     def _apply(self):
+        """
+        Add or update basic properties to display a scatter visual; Reset view
+        """
         self._reset_clim()
         if self._vispy_widget.scat_visual is None:
             self._vispy_widget.add_scatter_visual()
@@ -134,11 +127,14 @@ class ScatOptionsWidget(QtGui.QWidget):
             for idx in range(4):
                 self.stretch_sliders[idx].setValue(0)
 
-    def _reset_clim(self):
-        self.cmin = 'auto'
-        self.cmax = 'auto'
+    def _color_picker_show(self):
+        color = QtGui.QColorDialog.getColor()
+        self.true_color = color.name()
+        self.color_view.setScene(self.color_scene)
+        self.color_view.setBackgroundBrush(QtGui.QColor(self.true_color))
+        self.color_view.show()
 
-    def _color_changed(self):
+    def _color_change(self):
         self.color_view.setScene(self.color_scene)
         self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
         self.color_view.show()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -1,0 +1,102 @@
+import os
+import math
+
+from glue.external.qt import QtGui
+from glue.qt.widget_properties import CurrentComboProperty, TextProperty, ButtonProperty
+from glue.qt.qtutil import load_ui
+from glue.qt import get_qapp
+
+from vispy.color import get_colormaps
+
+__all__ = ["ScatterOptionsWidget"]
+
+UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
+
+
+class ScatOptionsWidget(QtGui.QWidget):
+
+    # AttributeError: 'ScatOptionsWidget' object has no attribute 'ui'
+    '''xlog = ButtonProperty('ui.xLogCheckBox', 'log scaling on x axis?')
+    ylog = ButtonProperty('ui.yLogCheckBox', 'log scaling on y axis?')
+    zlog = ButtonProperty('ui.zLogCheckBox', 'log scaling on z axis?')
+
+    xflip = ButtonProperty('ui.xFlipCheckBox', 'invert the x axis?')
+    yflip = ButtonProperty('ui.yFlipCheckBox', 'invert the y axis?')
+    zflip = ButtonProperty('ui.zFlipCheckBox', 'invert the z axis?')
+
+    xmin = TextProperty('ui.xmin', 'Lower x limit of plot')
+    xmax = TextProperty('ui.xmax', 'Upper x limit of plot')
+    ymin = TextProperty('ui.ymin', 'Lower y limit of plot')
+    ymax = TextProperty('ui.ymax', 'Upper y limit of plot')
+    zmin = TextProperty('ui.zmin', 'Lower z limit of plot')
+    zmax = TextProperty('ui.zmax', 'Upper z limit of plot')
+
+    hidden = ButtonProperty('ui.hidden_attributes', 'Show hidden attributes')
+
+    xatt = CurrentComboProperty('ui.xAxisComboBox',
+                                'Attribute to plot on x axis')
+    yatt = CurrentComboProperty('ui.yAxisComboBox',
+                                'Attribute to plot on y axis')
+    zatt = CurrentComboProperty('ui.zAxisComboBox',
+                                'Attribute to plot on z axis')'''
+
+    def __init__(self, parent=None, vispy_widget=None):
+
+        super(ScatOptionsWidget, self).__init__(parent=parent)
+
+        print('UI_Main', UI_MAIN)
+        self.ui = load_ui(UI_MAIN, self)
+        if self.ui is None:
+            raise Exception("Unable to load UI file: {0}".format(UI_MAIN))
+
+        self._event_lock = False
+
+        self._vispy_widget = vispy_widget
+        if vispy_widget is not None:
+            self._vispy_widget.options_widget = self
+
+        self._connect()
+
+    # From 2D scatter
+    def _connect(self):
+        ui = self.ui
+
+        ui.xAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
+        ui.yAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
+        ui.zAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
+
+        ui.xmin.returnPressed.connect(self._refresh_viewer)
+        ui.xmax.returnPressed.connect(self._refresh_viewer)
+        ui.ymin.returnPressed.connect(self._refresh_viewer)
+        ui.ymax.returnPressed.connect(self._refresh_viewer)
+        ui.zmin.returnPressed.connect(self._refresh_viewer)
+        ui.zmax.returnPressed.connect(self._refresh_viewer)
+
+        ui.reset_button.clicked.connect(self._reset_view)
+
+    # TODO: implement it
+    def set_valid_components(self, components):
+        self.ui.xAxisComboBox.clear()
+        self.ui.yAxisComboBox.clear()
+        self.ui.zAxisComboBox.clear()
+        for component in components:
+            self.ui.xAxisComboBox.addItem(component, component)
+            self.ui.yAxisComboBox.addItem(component, component)
+            self.ui.zAxisComboBox.addItem(component, component)
+
+    # Now just for reset clim
+    def _reset_view(self):
+        self._reset_clim()
+        self._refresh_viewer()
+
+    def _reset_clim(self):
+        self.xmin = 'auto'
+        self.xmax = 'auto'
+        self.ymin = 'auto'
+        self.ymax = 'auto'
+        self.zmin = 'auto'
+        self.zmax = 'auto'
+
+    def _refresh_viewer(self):
+        if self._vispy_widget is not None:
+            self._vispy_widget._refresh()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -3,6 +3,7 @@ import math
 
 from glue.external.qt import QtGui, QtCore
 from glue.qt.widget_properties import CurrentComboProperty, TextProperty, ValueProperty
+from vispy.scene.cameras import MagnifyCamera, Magnify1DCamera
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
 
@@ -49,6 +50,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.color_view.show()
 
         self.fila_flag = 0
+        self.cam_flag = 0
 
         self.true_color = self.color
 
@@ -68,6 +70,17 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.clim_max.returnPressed.connect(self._draw_clim)
         ui.advanceButton.clicked.connect(self._color_picker_show)
         ui.filaButton.clicked.connect(self.filament_show)
+        ui.magnifyButton.clicked.connect(self.magnify_show)
+
+    def magnify_show(self):
+        if self.cam_flag == 0:
+            self._vispy_widget.view.camera = MagnifyCamera()
+            self._vispy_widget.view.camera.rect = (-5, -5, 10, 10)
+            self.cam_flag = 1
+        else:
+            self._vispy_widget.view.camera = self._vispy_widget.turn_cam
+            self.cam_flag = 0
+            self._vispy_widget.canvas.update()
 
     def filament_show(self):
         if self._vispy_widget is not None and self.fila_flag == 0:

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -15,25 +15,6 @@ UI_MAIN = os.path.join(os.path.dirname(__file__), 'options_widget.ui')
 
 class ScatOptionsWidget(QtGui.QWidget):
 
-    # AttributeError: 'ScatOptionsWidget' object has no attribute 'ui'
-    '''xlog = ButtonProperty('ui.xLogCheckBox', 'log scaling on x axis?')
-    ylog = ButtonProperty('ui.yLogCheckBox', 'log scaling on y axis?')
-    zlog = ButtonProperty('ui.zLogCheckBox', 'log scaling on z axis?')
-
-    xflip = ButtonProperty('ui.xFlipCheckBox', 'invert the x axis?')
-    yflip = ButtonProperty('ui.yFlipCheckBox', 'invert the y axis?')
-    zflip = ButtonProperty('ui.zFlipCheckBox', 'invert the z axis?')
-
-    xmin = TextProperty('ui.xmin', 'Lower x limit of plot')
-    xmax = TextProperty('ui.xmax', 'Upper x limit of plot')
-    ymin = TextProperty('ui.ymin', 'Lower y limit of plot')
-    ymax = TextProperty('ui.ymax', 'Upper y limit of plot')
-    zmin = TextProperty('ui.zmin', 'Lower z limit of plot')
-    zmax = TextProperty('ui.zmax', 'Upper z limit of plot')
-
-    hidden = ButtonProperty('ui.hidden_attributes', 'Show hidden attributes')'''
-
-
     def __init__(self, parent=None, vispy_widget=None):
 
         super(ScatOptionsWidget, self).__init__(parent=parent)
@@ -49,42 +30,32 @@ class ScatOptionsWidget(QtGui.QWidget):
         if vispy_widget is not None:
             self._vispy_widget.options_widget = self
 
-        self.xatt = CurrentComboProperty('ui.xAxisComboBox')
-        self.yatt = CurrentComboProperty('ui.yAxisComboBox')
-        self.zatt = CurrentComboProperty('ui.zAxisComboBox')
         self._connect()
 
     # From 2D scatter
     def _connect(self):
         ui = self.ui
 
-        ui.xAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
-        ui.yAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
-        ui.zAxisComboBox.currentIndexChanged.connect(self._refresh_viewer)
-
-        ui.xmin.returnPressed.connect(self._refresh_viewer)
-        ui.xmax.returnPressed.connect(self._refresh_viewer)
-        ui.ymin.returnPressed.connect(self._refresh_viewer)
-        ui.ymax.returnPressed.connect(self._refresh_viewer)
-        ui.zmin.returnPressed.connect(self._refresh_viewer)
-        ui.zmax.returnPressed.connect(self._refresh_viewer)
-
         ui.axis_apply.clicked.connect(self._refresh_program)
         ui.reset_button.clicked.connect(self._reset_view)
 
-    # TODO: implement it
     def set_valid_components(self, components):
         self.ui.xAxisComboBox.clear()
         self.ui.yAxisComboBox.clear()
         self.ui.zAxisComboBox.clear()
+        self.ui.SizeComboBox.clear()
         for component in components:
             self.ui.xAxisComboBox.addItem(component, component)
             self.ui.yAxisComboBox.addItem(component, component)
             self.ui.zAxisComboBox.addItem(component, component)
+            self.ui.SizeComboBox.addItem(component, component)
 
-    # Now just for reset clim
-    def _reset_view(self):
+    def _apply(self):
         self._reset_clim()
+        self._refresh_program()
+
+    def _reset_view(self):
+        # self._reset_clim()
         self._refresh_viewer()
 
     def _reset_clim(self):
@@ -95,10 +66,12 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.zmin = 'auto'
         self.zmax = 'auto'
 
+    # TODO: self._vispy_widget._refresh() is empty now
     def _refresh_viewer(self):
         if self._vispy_widget is not None:
             self._vispy_widget._refresh()
 
     def _refresh_program(self):
+
         if self._vispy_widget is not None:
             self._vispy_widget.set_program()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -40,21 +40,12 @@ class ScatOptionsWidget(QtGui.QWidget):
         for map_name in get_color_names():
             self.ui.ColorComboBox.addItem(map_name, map_name)
 
-
-        '''scene = QtGui.QGraphicsScene()
-        scene.addText("Hello, world!")
-        view = self.ui.graphicsView
-        view.show()'''
-
-
+        # Add a color display area here
         # self.opacity = self.ui.opacity.value()
         self.color_view = self.ui.graphicsView
-        print('=======')
-        print('Color_view and color is: first !', self.color_view, self.color)
         self.color_scene = QtGui.QGraphicsScene()
-        self.color_scene.setBackgroundBrush(QtGui.QColor(self.color))
+        self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
         self.color_view.setScene(self.color_scene)
-        # self.color_view.update()
         self.color_view.show()
 
         self._connect()
@@ -90,7 +81,6 @@ class ScatOptionsWidget(QtGui.QWidget):
             self._vispy_widget._update_clim()
 
     def _draw_clim(self):
-
         # Pick the dataset between the threshold and draw them in different symbol
         # Add another visual into it?
         if self._vispy_widget is not None:
@@ -109,18 +99,11 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.cmax = 'auto'
 
     def _color_changed(self):
-        # Set color display
-        self.color_scene.setBackgroundBrush(QtGui.QColor(self.color))
         self.color_view.setScene(self.color_scene)
-        # self.color_view.render(QtGui.QPainter())
-        print('=======')
-        print('Color_view and color is:', self.color_view, self.color, self.ui.axis_apply)
         self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
-
         self.color_view.show()
-        # self.color_view.update()
 
-        self._refresh_program()
+        # self._refresh_program()
 
     # TODO: self._vispy_widget._refresh() is empty now
     def _refresh_viewer(self):

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -31,14 +31,8 @@ class ScatOptionsWidget(QtGui.QWidget):
     zmin = TextProperty('ui.zmin', 'Lower z limit of plot')
     zmax = TextProperty('ui.zmax', 'Upper z limit of plot')
 
-    hidden = ButtonProperty('ui.hidden_attributes', 'Show hidden attributes')
+    hidden = ButtonProperty('ui.hidden_attributes', 'Show hidden attributes')'''
 
-    xatt = CurrentComboProperty('ui.xAxisComboBox',
-                                'Attribute to plot on x axis')
-    yatt = CurrentComboProperty('ui.yAxisComboBox',
-                                'Attribute to plot on y axis')
-    zatt = CurrentComboProperty('ui.zAxisComboBox',
-                                'Attribute to plot on z axis')'''
 
     def __init__(self, parent=None, vispy_widget=None):
 
@@ -55,6 +49,9 @@ class ScatOptionsWidget(QtGui.QWidget):
         if vispy_widget is not None:
             self._vispy_widget.options_widget = self
 
+        self.xatt = CurrentComboProperty('ui.xAxisComboBox')
+        self.yatt = CurrentComboProperty('ui.yAxisComboBox')
+        self.zatt = CurrentComboProperty('ui.zAxisComboBox')
         self._connect()
 
     # From 2D scatter
@@ -72,6 +69,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.zmin.returnPressed.connect(self._refresh_viewer)
         ui.zmax.returnPressed.connect(self._refresh_viewer)
 
+        ui.axis_apply.clicked.connect(self._refresh_program)
         ui.reset_button.clicked.connect(self._reset_view)
 
     # TODO: implement it
@@ -100,3 +98,7 @@ class ScatOptionsWidget(QtGui.QWidget):
     def _refresh_viewer(self):
         if self._vispy_widget is not None:
             self._vispy_widget._refresh()
+
+    def _refresh_program(self):
+        if self._vispy_widget is not None:
+            self._vispy_widget.set_program()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -65,6 +65,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
         ui.ColorComboBox.currentIndexChanged.connect(self._color_changed)
         ui.OpacitySlider.valueChanged.connect(self._refresh_program)
+        ui.sizeSlider.valueChanged.connect(self._refresh_program)
 
         ui.clim_min.returnPressed.connect(self._draw_clim)
         ui.clim_max.returnPressed.connect(self._draw_clim)

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -66,18 +66,18 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.color_view.show()
 
         self.true_color = self.color
-
+        self._reset_clim()
         self._connect()
 
     def _connect(self):
         self.ui.axis_apply.clicked.connect(self._apply)
-        self.ui.reset_button.clicked.connect(self._apply)
+        self.ui.reset_button.clicked.connect(self._reset_view)
         self.ui.ClimComboBox.currentIndexChanged.connect(self._clim_combo_change)
         self.ui.ColorComboBox.currentIndexChanged.connect(self._color_change)
         self.ui.OpacitySlider.valueChanged.connect(self._refresh_viewer)
 
-        self.ui.clim_min.returnPressed.connect(self._apply_clim)
-        self.ui.clim_max.returnPressed.connect(self._apply_clim)
+        self.ui.clim_min.returnPressed.connect(self._refresh_viewer)
+        self.ui.clim_max.returnPressed.connect(self._refresh_viewer)
         self.ui.advanceButton.clicked.connect(self._color_picker_show)
 
         # Connect slider and values both ways
@@ -107,7 +107,7 @@ class ScatOptionsWidget(QtGui.QWidget):
 
     def _clim_combo_change(self):
         if self._vispy_widget is not None:
-            self._vispy_widget.update_clim()
+            self._vispy_widget._update_clim()
 
     def _apply_clim(self):
         if self._vispy_widget is not None:
@@ -115,17 +115,26 @@ class ScatOptionsWidget(QtGui.QWidget):
 
     def _apply(self):
         """
-        Add or update basic properties to display a scatter visual; Reset view
+        Add or update basic properties to display a scatter visual
         """
-        self._reset_clim()
         if self._vispy_widget.scat_visual is None:
             self._vispy_widget.add_scatter_visual()
         else:
             # Only axis & size combo refresh
-            self._vispy_widget.update_scatter_visual()
-            # Reset slider bars
-            for idx in range(4):
-                self.stretch_sliders[idx].setValue(0)
+            self._reset_clim()
+            self._refresh_viewer()
+
+    def _reset_view(self):
+        """
+        Reset sliders, camera, clim combobox & text
+        """
+        for idx in range(4):
+            self.stretch_sliders[idx].setValue(0)
+        self._reset_clim()
+
+        if self._vispy_widget is not None:
+            self._vispy_widget.view.camera.reset()
+        self._refresh_viewer()
 
     def _color_picker_show(self):
         color = QtGui.QColorDialog.getColor()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -40,7 +40,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui = self.ui
 
         ui.axis_apply.clicked.connect(self._apply)
-        ui.reset_button.clicked.connect(self._reset_view)
+        ui.reset_button.clicked.connect(self._apply)
         ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
         ui.clim_min.returnPressed.connect(self._draw_clim)
         ui.clim_max.returnPressed.connect(self._draw_clim)
@@ -63,9 +63,11 @@ class ScatOptionsWidget(QtGui.QWidget):
             self._vispy_widget._update_clim()
 
     def _draw_clim(self):
-        return
+
         # Pick the dataset between the threshold and draw them in different symbol
         # Add another visual into it?
+        if self._vispy_widget is not None:
+            self._vispy_widget.apply_clim()
 
     def _apply(self):
         self._reset_clim()

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -1,7 +1,7 @@
 import os
 import math
 
-from glue.external.qt import QtGui
+from glue.external.qt import QtGui, QtCore
 from glue.qt.widget_properties import CurrentComboProperty, TextProperty, ValueProperty
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
@@ -37,10 +37,25 @@ class ScatOptionsWidget(QtGui.QWidget):
             self._vispy_widget.options_widget = self
 
         # There are 155 color options
-        for map_name in get_color_names()[0:40]:
+        for map_name in get_color_names():
             self.ui.ColorComboBox.addItem(map_name, map_name)
 
+
+        '''scene = QtGui.QGraphicsScene()
+        scene.addText("Hello, world!")
+        view = self.ui.graphicsView
+        view.show()'''
+
+
         # self.opacity = self.ui.opacity.value()
+        self.color_view = self.ui.graphicsView
+        print('=======')
+        print('Color_view and color is: first !', self.color_view, self.color)
+        self.color_scene = QtGui.QGraphicsScene()
+        self.color_scene.setBackgroundBrush(QtGui.QColor(self.color))
+        self.color_view.setScene(self.color_scene)
+        # self.color_view.update()
+        self.color_view.show()
 
         self._connect()
 
@@ -51,7 +66,7 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.axis_apply.clicked.connect(self._apply)
         ui.reset_button.clicked.connect(self._apply)
         ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
-        ui.ColorComboBox.currentIndexChanged.connect(self._refresh_program)
+        ui.ColorComboBox.currentIndexChanged.connect(self._color_changed)
         ui.OpacitySlider.valueChanged.connect(self._refresh_program)
 
         ui.clim_min.returnPressed.connect(self._draw_clim)
@@ -92,6 +107,20 @@ class ScatOptionsWidget(QtGui.QWidget):
     def _reset_clim(self):
         self.cmin = 'auto'
         self.cmax = 'auto'
+
+    def _color_changed(self):
+        # Set color display
+        self.color_scene.setBackgroundBrush(QtGui.QColor(self.color))
+        self.color_view.setScene(self.color_scene)
+        # self.color_view.render(QtGui.QPainter())
+        print('=======')
+        print('Color_view and color is:', self.color_view, self.color, self.ui.axis_apply)
+        self.color_view.setBackgroundBrush(QtGui.QColor(self.color))
+
+        self.color_view.show()
+        # self.color_view.update()
+
+        self._refresh_program()
 
     # TODO: self._vispy_widget._refresh() is empty now
     def _refresh_viewer(self):

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -2,11 +2,11 @@ import os
 import math
 
 from glue.external.qt import QtGui
-from glue.qt.widget_properties import CurrentComboProperty, TextProperty, ButtonProperty
+from glue.qt.widget_properties import CurrentComboProperty, TextProperty, ValueProperty
 from glue.qt.qtutil import load_ui
 from glue.qt import get_qapp
 
-from vispy.color import get_colormaps
+from vispy.color import get_colormaps, get_color_dict, get_color_names
 
 __all__ = ["ScatterOptionsWidget"]
 
@@ -17,6 +17,9 @@ class ScatOptionsWidget(QtGui.QWidget):
 
     cmin = TextProperty('ui.clim_min')
     cmax = TextProperty('ui.clim_max')
+
+    color = CurrentComboProperty('ui.ColorComboBox')
+    opacity = ValueProperty('ui.OpacitySlider')
 
     def __init__(self, parent=None, vispy_widget=None):
 
@@ -33,6 +36,12 @@ class ScatOptionsWidget(QtGui.QWidget):
         if vispy_widget is not None:
             self._vispy_widget.options_widget = self
 
+        # There are 155 color options
+        for map_name in get_color_names()[0:40]:
+            self.ui.ColorComboBox.addItem(map_name, map_name)
+
+        # self.opacity = self.ui.opacity.value()
+
         self._connect()
 
     # From 2D scatter
@@ -42,6 +51,9 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.axis_apply.clicked.connect(self._apply)
         ui.reset_button.clicked.connect(self._apply)
         ui.ClimComboBox.currentIndexChanged.connect(self._clim_change)
+        ui.ColorComboBox.currentIndexChanged.connect(self._refresh_program)
+        ui.OpacitySlider.valueChanged.connect(self._refresh_program)
+
         ui.clim_min.returnPressed.connect(self._draw_clim)
         ui.clim_max.returnPressed.connect(self._draw_clim)
 

--- a/glue_vispy_viewers/scatter/options_widget.py
+++ b/glue_vispy_viewers/scatter/options_widget.py
@@ -48,6 +48,8 @@ class ScatOptionsWidget(QtGui.QWidget):
         self.color_view.setScene(self.color_scene)
         self.color_view.show()
 
+        self.fila_flag = 0
+
         self.true_color = self.color
 
         self._connect()
@@ -65,6 +67,12 @@ class ScatOptionsWidget(QtGui.QWidget):
         ui.clim_min.returnPressed.connect(self._draw_clim)
         ui.clim_max.returnPressed.connect(self._draw_clim)
         ui.advanceButton.clicked.connect(self._color_picker_show)
+        ui.filaButton.clicked.connect(self.filament_show)
+
+    def filament_show(self):
+        if self._vispy_widget is not None and self.fila_flag == 0:
+            self._vispy_widget.add_fila()
+            self.fila_flag = 1
 
     def _color_picker_show(self):
         color = QtGui.QColorDialog.getColor()

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>287</width>
-    <height>292</height>
+    <width>284</width>
+    <height>498</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -153,38 +153,59 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Color</string>
-          </property>
-         </widget>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="2" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QGraphicsView" name="graphicsView">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>112</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="backgroundBrush">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>255</red>
+               <green>255</green>
+               <blue>255</blue>
+              </color>
+             </brush>
+            </property>
+            <property name="cacheMode">
+             <set>QGraphicsView::CacheBackground</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item>
-         <widget class="QComboBox" name="ColorComboBox"/>
-        </item>
-        <item>
-         <widget class="QGraphicsView" name="graphicsView">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="backgroundBrush">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </brush>
-          </property>
-          <property name="cacheMode">
-           <set>QGraphicsView::CacheBackground</set>
-          </property>
-         </widget>
+        <item row="0" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Color</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="ColorComboBox"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="advanceButton">
+            <property name="text">
+             <string>Advance</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -215,12 +215,12 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QPushButton" name="snapLimits">
+         <widget class="QPushButton" name="axis_apply">
           <property name="toolTip">
            <string>Rescale plot limits to fit data</string>
           </property>
           <property name="text">
-           <string>Auto scale</string>
+           <string>Apply</string>
           </property>
          </widget>
         </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -63,12 +63,12 @@
        <number>10</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4,0">
+       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4,0,0">
         <property name="spacing">
          <number>8</number>
         </property>
         <item>
-         <widget class="QLabel" name="xlabel">
+         <widget class="QLabel" name="x_lab">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;x axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -91,21 +91,30 @@
          </widget>
         </item>
         <item>
-         <widget class="QSlider" name="horizontalSlider">
+         <widget class="QSlider" name="x_stretch_slider">
+          <property name="minimum">
+           <number>-10000</number>
+          </property>
+          <property name="maximum">
+           <number>10000</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QLineEdit" name="x_val"/>
+        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4,0">
+       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4,0,0">
         <property name="spacing">
          <number>8</number>
         </property>
         <item>
-         <widget class="QLabel" name="ylabel">
+         <widget class="QLabel" name="y_lab">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#00ff00;&quot;&gt;y axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -128,21 +137,30 @@
          </widget>
         </item>
         <item>
-         <widget class="QSlider" name="horizontalSlider_2">
+         <widget class="QSlider" name="y_stretch_slider">
+          <property name="minimum">
+           <number>-10000</number>
+          </property>
+          <property name="maximum">
+           <number>10000</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QLineEdit" name="y_val"/>
+        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4,0">
+       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4,0,0">
         <property name="spacing">
          <number>8</number>
         </property>
         <item>
-         <widget class="QLabel" name="zlabel">
+         <widget class="QLabel" name="z_lab">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#0000ff;&quot;&gt;z axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -165,11 +183,20 @@
          </widget>
         </item>
         <item>
-         <widget class="QSlider" name="horizontalSlider_3">
+         <widget class="QSlider" name="z_stretch_slider">
+          <property name="minimum">
+           <number>-10000</number>
+          </property>
+          <property name="maximum">
+           <number>10000</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
          </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="z_val"/>
         </item>
        </layout>
       </item>
@@ -270,12 +297,12 @@
          </widget>
         </item>
         <item>
-         <widget class="QSlider" name="sizeSlider">
+         <widget class="QSlider" name="size_stretch_slider">
           <property name="minimum">
-           <number>1</number>
+           <number>-10000</number>
           </property>
           <property name="maximum">
-           <number>100</number>
+           <number>10000</number>
           </property>
           <property name="value">
            <number>1</number>
@@ -284,6 +311,9 @@
            <enum>Qt::Horizontal</enum>
           </property>
          </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="size_val"/>
         </item>
        </layout>
       </item>
@@ -404,28 +434,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QPushButton" name="filaButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Filament Show</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="magnifyButton">
-          <property name="text">
-           <string>Magnify</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <layout class="QHBoxLayout" name="horizontalLayout_8"/>
       </item>
       <item>
        <spacer name="verticalSpacer">

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -205,7 +205,11 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="ClimComboBox"/>
+         <widget class="QComboBox" name="ClimComboBox">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -353,17 +353,28 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="filaButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Filament Show</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QPushButton" name="filaButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Filament Show</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="magnifyButton">
+          <property name="text">
+           <string>Magnify</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <spacer name="verticalSpacer">

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -63,7 +63,7 @@
        <number>10</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4">
+       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4,0">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -90,10 +90,17 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QSlider" name="horizontalSlider">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4">
+       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4,0">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -120,10 +127,17 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QSlider" name="horizontalSlider_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4">
+       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4,0">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -147,6 +161,13 @@
           </property>
           <property name="sizeAdjustPolicy">
            <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="horizontalSlider_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -231,6 +252,36 @@
           </property>
           <property name="text">
            <string>Apply</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Size Change</string>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="sizeSlider">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -180,6 +180,47 @@
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Color</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="ColorComboBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="opacity_label">
+          <property name="text">
+           <string>Opacity</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="OpacitySlider">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="Line" name="line">
         <property name="frameShadow">
          <enum>QFrame::Sunken</enum>
@@ -265,13 +306,6 @@
        <widget class="QPushButton" name="reset_button">
         <property name="text">
          <string>Reset Limit</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Color</string>
         </property>
        </widget>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -196,25 +196,23 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Sunken</enum>
-        </property>
-        <property name="text">
-         <string>Plot Limits</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="clim_label">
+          <property name="text">
+           <string>Plot Limit</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="ClimComboBox"/>
+        </item>
+       </layout>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QLabel" name="xmin_label">
+         <widget class="QLabel" name="cmin_label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -228,15 +226,15 @@
            </size>
           </property>
           <property name="text">
-           <string>x min</string>
+           <string>Min</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="xmin"/>
+         <widget class="QLineEdit" name="clim_min"/>
         </item>
         <item>
-         <widget class="QLabel" name="xmax_label">
+         <widget class="QLabel" name="cmax_label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -250,115 +248,26 @@
            </size>
           </property>
           <property name="text">
-           <string>x max</string>
+           <string>Max</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="xmax"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="ymin_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>y min</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="ymin"/>
-        </item>
-        <item>
-         <widget class="QLabel" name="ymax_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>y max</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="ymax"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="zmin_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>z min</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="zmin"/>
-        </item>
-        <item>
-         <widget class="QLabel" name="zmax_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>z max</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="zmax"/>
+         <widget class="QLineEdit" name="clim_max"/>
         </item>
        </layout>
       </item>
       <item>
        <widget class="QPushButton" name="reset_button">
         <property name="text">
-         <string>Reset</string>
+         <string>Reset Limit</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Color</string>
         </property>
        </widget>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -153,33 +153,6 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="sizelabel">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="SizeComboBox"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="axis_apply">
-          <property name="toolTip">
-           <string>Rescale plot limits to fit data</string>
-          </property>
-          <property name="text">
-           <string>Apply</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
          <widget class="QLabel" name="label_2">
@@ -210,6 +183,33 @@
           </property>
           <property name="cacheMode">
            <set>QGraphicsView::CacheBackground</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="sizelabel">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="SizeComboBox"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="axis_apply">
+          <property name="toolTip">
+           <string>Rescale plot limits to fit data</string>
+          </property>
+          <property name="text">
+           <string>Apply</string>
           </property>
          </widget>
         </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ScatterWidget</class>
+ <widget class="QWidget" name="ScatterWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>287</width>
+    <height>268</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>3</horstretch>
+    <verstretch>3</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>555</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::StrongFocus</enum>
+  </property>
+  <property name="windowTitle">
+   <string>Scatter Plot</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>3</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="option_dashboard" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>10</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4,0,0">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="xlabel">
+          <property name="text">
+           <string>x axis</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="xAxisComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Set which attribute is plotted on the x axis</string>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="xLogCheckBox">
+          <property name="toolTip">
+           <string>Toggle on/off log scaling on the x axis</string>
+          </property>
+          <property name="text">
+           <string>log</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="xFlipCheckBox">
+          <property name="toolTip">
+           <string>Flip/unflip the order of the x axis</string>
+          </property>
+          <property name="text">
+           <string>flip</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4,0,0">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="ylabel">
+          <property name="text">
+           <string>y axis</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="yAxisComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Set which attribute is plotted on the y axis</string>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="yLogCheckBox">
+          <property name="toolTip">
+           <string>Toggle on/off log scaling on the y axis</string>
+          </property>
+          <property name="text">
+           <string>log</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="yFlipCheckBox">
+          <property name="toolTip">
+           <string>Flip/unflip the order of the y axis</string>
+          </property>
+          <property name="text">
+           <string>flip</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4,0,0">
+        <property name="spacing">
+         <number>8</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="zlabel">
+          <property name="text">
+           <string>z axis</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="zAxisComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Set which attribute is plotted on the z axis</string>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="zLogCheckBox">
+          <property name="toolTip">
+           <string>Toggle on/off log scaling on the z axis</string>
+          </property>
+          <property name="text">
+           <string>log</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="zFlipCheckBox">
+          <property name="toolTip">
+           <string>Flip/unflip the order of the z axis</string>
+          </property>
+          <property name="text">
+           <string>flip</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QPushButton" name="snapLimits">
+          <property name="toolTip">
+           <string>Rescale plot limits to fit data</string>
+          </property>
+          <property name="text">
+           <string>Auto scale</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="swapAxes">
+          <property name="toolTip">
+           <string>Swap what's plotted on the x and y axes</string>
+          </property>
+          <property name="text">
+           <string>Swap Axes</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="hidden_attributes">
+        <property name="text">
+         <string>show hidden attributes</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
+        </property>
+        <property name="lineWidth">
+         <number>2</number>
+        </property>
+        <property name="midLineWidth">
+         <number>0</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
+        </property>
+        <property name="text">
+         <string>Plot Limits</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="xmin_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>x min</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="xmin"/>
+        </item>
+        <item>
+         <widget class="QLabel" name="xmax_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>x max</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="xmax"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="ymin_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>y min</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ymin"/>
+        </item>
+        <item>
+         <widget class="QLabel" name="ymax_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>y max</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ymax"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="zmin_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>z min</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="zmin"/>
+        </item>
+        <item>
+         <widget class="QLabel" name="zmax_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>z max</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="zmax"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QPushButton" name="reset_button">
+        <property name="text">
+         <string>Reset</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>1</width>
+          <height>1</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -191,6 +191,28 @@
         <item>
          <widget class="QComboBox" name="ColorComboBox"/>
         </item>
+        <item>
+         <widget class="QGraphicsView" name="graphicsView">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="backgroundBrush">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>255</red>
+             <green>255</green>
+             <blue>255</blue>
+            </color>
+           </brush>
+          </property>
+          <property name="cacheMode">
+           <set>QGraphicsView::CacheBackground</set>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>284</width>
-    <height>498</height>
+    <height>530</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -349,6 +349,19 @@
        <widget class="QPushButton" name="reset_button">
         <property name="text">
          <string>Reset Limit</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="filaButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Filament Show</string>
         </property>
        </widget>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -429,7 +429,7 @@
       <item>
        <widget class="QPushButton" name="reset_button">
         <property name="text">
-         <string>Reset Limit</string>
+         <string>Reset View</string>
         </property>
        </widget>
       </item>

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>287</width>
-    <height>268</height>
+    <height>292</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -63,7 +63,7 @@
        <number>10</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4,0,0">
+       <layout class="QHBoxLayout" name="xAxisLayout" stretch="0,4">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -90,30 +90,10 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="xLogCheckBox">
-          <property name="toolTip">
-           <string>Toggle on/off log scaling on the x axis</string>
-          </property>
-          <property name="text">
-           <string>log</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="xFlipCheckBox">
-          <property name="toolTip">
-           <string>Flip/unflip the order of the x axis</string>
-          </property>
-          <property name="text">
-           <string>flip</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4,0,0">
+       <layout class="QHBoxLayout" name="yAxisLayout" stretch="0,4">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -140,30 +120,10 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="yLogCheckBox">
-          <property name="toolTip">
-           <string>Toggle on/off log scaling on the y axis</string>
-          </property>
-          <property name="text">
-           <string>log</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="yFlipCheckBox">
-          <property name="toolTip">
-           <string>Flip/unflip the order of the y axis</string>
-          </property>
-          <property name="text">
-           <string>flip</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4,0,0">
+       <layout class="QHBoxLayout" name="zAxisLayout" stretch="0,4">
         <property name="spacing">
          <number>8</number>
         </property>
@@ -190,30 +150,23 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="zLogCheckBox">
-          <property name="toolTip">
-           <string>Toggle on/off log scaling on the z axis</string>
-          </property>
-          <property name="text">
-           <string>log</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="zFlipCheckBox">
-          <property name="toolTip">
-           <string>Flip/unflip the order of the z axis</string>
-          </property>
-          <property name="text">
-           <string>flip</string>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="sizelabel">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="SizeComboBox"/>
+        </item>
         <item>
          <widget class="QPushButton" name="axis_apply">
           <property name="toolTip">
@@ -224,24 +177,7 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QPushButton" name="swapAxes">
-          <property name="toolTip">
-           <string>Swap what's plotted on the x and y axes</string>
-          </property>
-          <property name="text">
-           <string>Swap Axes</string>
-          </property>
-         </widget>
-        </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="hidden_attributes">
-        <property name="text">
-         <string>show hidden attributes</string>
-        </property>
-       </widget>
       </item>
       <item>
        <widget class="Line" name="line">

--- a/glue_vispy_viewers/scatter/options_widget.ui
+++ b/glue_vispy_viewers/scatter/options_widget.ui
@@ -70,7 +70,7 @@
         <item>
          <widget class="QLabel" name="xlabel">
           <property name="text">
-           <string>x axis</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;x axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -107,7 +107,7 @@
         <item>
          <widget class="QLabel" name="ylabel">
           <property name="text">
-           <string>y axis</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#00ff00;&quot;&gt;y axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -144,7 +144,7 @@
         <item>
          <widget class="QLabel" name="zlabel">
           <property name="text">
-           <string>z axis</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#0000ff;&quot;&gt;z axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -80,7 +80,7 @@ class ScatVispyViewer(DataViewer):
 
     def _redraw(self):
         # self._vispy_widget.on_draw()
-        self._vispy_widget.canvas.render()
+        # self._vispy_widget.canvas.render()
         self._vispy_widget.canvas.show()
         self._vispy_widget.canvas.update()
 

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -1,0 +1,108 @@
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.core import message as msg
+
+from .scat_vispy_widget import QtScatVispyWidget
+
+class ScatVispyViewer(DataViewer):
+
+    LABEL = "3D Scatter Plot"
+
+    def __init__(self, session, parent=None):
+
+        super(ScatVispyViewer, self).__init__(session, parent=parent)
+
+        self._vispy_widget = QtScatVispyWidget()
+        self._canvas = self._vispy_widget.canvas
+        self.viewer_size = [600, 400]
+        self._canvas.size = self.viewer_size
+        self.setCentralWidget(self._canvas.native)
+
+        # Should be put in on_resize but put here first to set the projection for gloo
+        self._vispy_widget.set_projection()
+
+        self._data = None
+        self._subsets = []
+
+    def register_to_hub(self, hub):
+
+        super(ScatVispyViewer, self).register_to_hub(hub)
+
+        dfilter = lambda x: True
+        dcfilter = lambda x: True
+        subfilter = lambda x: True
+
+        hub.subscribe(self, msg.SubsetCreateMessage,
+                      handler=self._add_subset,
+                      filter=dfilter)
+
+        hub.subscribe(self, msg.SubsetUpdateMessage,
+                      handler=self._update_subset,
+                      filter=subfilter)
+
+        hub.subscribe(self, msg.SubsetDeleteMessage,
+                      handler=self._remove_subset)
+
+        hub.subscribe(self, msg.DataUpdateMessage,
+                      handler=self.update_window_title)
+
+    def add_data(self, data):
+        self._data = data
+        self._update_data()
+        return True
+
+    def _add_subset(self, message):
+        self._subsets.append(message.subset)
+        self._update_subsets()
+
+    def _update_subset(self, message):
+        self._update_subsets()
+
+    def _remove_subset(self, message):
+        self._subsets.remove(message.subset)
+        self._update_subsets()
+
+    def _update_data(self):
+        self._vispy_widget.set_data(self._data)
+        # data = self._vispy_widget.get_data()
+        self._vispy_widget.set_program()
+        self._vispy_widget.set_projection()
+        # self._options_widget.init_viewer()
+        # print('data position is:', self._vispy_widget.data['a_position'])
+        self._redraw()
+
+    def _update_subsets(self):
+        # TODO: in future, we should be smarter and not compute the masks just
+        # for style changes, but this will do for now for experimentation.
+        self._vispy_widget.set_subsets([{'mask': s.to_mask(),
+                                         'color': s.style.color,
+                                         'alpha': s.style.alpha} for s in self._subsets])
+        self._redraw()
+
+    def _redraw(self):
+        # self._vispy_widget.on_draw()
+        self._vispy_widget.canvas.render()
+        self._vispy_widget.canvas.show()
+        self._vispy_widget.canvas.update()
+
+    @property
+    def window_title(self):
+        c = self.client.component
+        if c is not None:
+            label = str(c.label)
+        else:
+            label = '3D Scatter Plot'
+        return label
+
+    # Add side panels
+    '''def layer_view(self):
+        return self._layer_view'''
+
+    def add_subset(self, subset):
+        pass
+
+    def restore_layers(self, rec, context):
+        pass
+
+    def notify(self, message):
+        pass
+

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -2,6 +2,8 @@ from glue.qt.widgets.data_viewer import DataViewer
 from glue.core import message as msg
 
 from .scat_vispy_widget import QtScatVispyWidget
+from .options_widget import ScatOptionsWidget
+
 
 class ScatVispyViewer(DataViewer):
 
@@ -18,6 +20,8 @@ class ScatVispyViewer(DataViewer):
         self.setCentralWidget(self._canvas.native)
         self._data = None
         self._subsets = []
+        self._options_widget = ScatOptionsWidget(vispy_widget=self._vispy_widget)
+
 
     def register_to_hub(self, hub):
 
@@ -95,4 +99,7 @@ class ScatVispyViewer(DataViewer):
 
     def notify(self, message):
         pass
+
+    def options_widget(self):
+        return self._options_widget
 

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -16,10 +16,6 @@ class ScatVispyViewer(DataViewer):
         self.viewer_size = [600, 400]
         self._canvas.size = self.viewer_size
         self.setCentralWidget(self._canvas.native)
-
-        # Should be put in on_resize but put here first to set the projection for gloo
-        self._vispy_widget.set_projection()
-
         self._data = None
         self._subsets = []
 
@@ -63,11 +59,7 @@ class ScatVispyViewer(DataViewer):
 
     def _update_data(self):
         self._vispy_widget.set_data(self._data)
-        # data = self._vispy_widget.get_data()
         self._vispy_widget.set_program()
-        # self._vispy_widget.set_projection()
-        # self._options_widget.init_viewer()
-        # print('data position is:', self._vispy_widget.data['a_position'])
         self._redraw()
 
     def _update_subsets(self):
@@ -79,8 +71,6 @@ class ScatVispyViewer(DataViewer):
         self._redraw()
 
     def _redraw(self):
-        # self._vispy_widget.on_draw()
-        # self._vispy_widget.canvas.render()
         self._vispy_widget.canvas.show()
         self._vispy_widget.canvas.update()
 

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -65,7 +65,7 @@ class ScatVispyViewer(DataViewer):
         self._vispy_widget.set_data(self._data)
         # data = self._vispy_widget.get_data()
         self._vispy_widget.set_program()
-        self._vispy_widget.set_projection()
+        # self._vispy_widget.set_projection()
         # self._options_widget.init_viewer()
         # print('data position is:', self._vispy_widget.data['a_position'])
         self._redraw()

--- a/glue_vispy_viewers/scatter/scat_vispy_viewer.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_viewer.py
@@ -62,8 +62,8 @@ class ScatVispyViewer(DataViewer):
         self._update_subsets()
 
     def _update_data(self):
-        self._vispy_widget.set_data(self._data)
-        self._vispy_widget.set_program()
+        self._vispy_widget.data = self._data
+        # self._vispy_widget.set_program()
         self._redraw()
 
     def _update_subsets(self):

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -59,6 +59,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         # TODO: resize of the grid?
         print('==============')
         print('canvas size', self.canvas.size)
+        print('view size', self.view.size)
         a = 400 - self.canvas.size[0]/2.0
         b = 300 - self.canvas.size[1]/2.0
         # self.grid.transform = transforms.STTransform(translate=(a, b))
@@ -131,7 +132,7 @@ class QtScatVispyWidget(QtGui.QWidget):
             S[...] = self.components[3] ** (1. / 3) / 1.e1
 
 
-            scatter_color =Color(self.options_widget.color, self.options_widget.opacity/100.0)
+            scatter_color =Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
 
             # Set default color = 'gold'
             print('=============')
@@ -173,7 +174,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         # Dot size determination according to the mass - *2 for larger size
         S = np.zeros(n)
         S[...] = _clim_components[3] ** (1. / 3) / 1.e1
-        scatter_color =Color(self.options_widget.color, self.options_widget.opacity/100.0)
+        scatter_color =Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
 
         # Reset the data for scatter visual display
         self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -4,267 +4,42 @@ import sys
 
 import numpy as np
 from glue.external.qt import QtGui
-from vispy import scene, app, gloo
-from vispy import gloo
-from vispy.util.transforms import perspective, translate, rotate
-
+from vispy import scene, app
+from vispy.color import get_colormap
 
 __all__ = ['QtScatVispyWidget']
 
-
-
+# TODO : create a custom visual inherited from Markers
 class QtScatVispyWidget(QtGui.QWidget):
-
     def __init__(self, parent=None):
 
         super(QtScatVispyWidget, self).__init__(parent=parent)
 
-        vert ="""
-        #version 120
-
-        // Uniforms
-        // ------------------------------------
-        uniform mat4 u_model;
-        uniform mat4 u_view;
-        uniform mat4 u_projection;
-        uniform float u_linewidth;
-        uniform float u_antialias;
-        uniform float u_size;
-
-        // Attributes
-        // ------------------------------------
-        attribute vec3  a_position;
-        attribute vec4  a_fg_color;
-        attribute vec4  a_bg_color;
-        attribute float a_size;
-
-        // Varyings
-        // ------------------------------------
-        varying vec4 v_fg_color;
-        varying vec4 v_bg_color;
-        varying float v_size;
-        varying float v_linewidth;
-        varying float v_antialias;
-
-        void main (void) {
-            v_size = a_size * u_size;
-            v_linewidth = u_linewidth;
-            v_antialias = u_antialias;
-            v_fg_color  = a_fg_color;
-            v_bg_color  = a_bg_color;
-            gl_Position = u_projection * u_view * u_model * vec4(a_position,1.0);
-            gl_PointSize = v_size + 2*(v_linewidth + 1.5*v_antialias);
-        }
-        """
-
-
-        frag = """
-        #version 120
-
-        // Constants
-        // ------------------------------------
-
-
-        // Varyings
-        // ------------------------------------
-        varying vec4 v_fg_color;
-        varying vec4 v_bg_color;
-        varying float v_size;
-        varying float v_linewidth;
-        varying float v_antialias;
-
-        // Functions
-        // ------------------------------------
-
-        // ----------------
-        float disc(vec2 P, float size)
-        {
-            float r = length((P.xy - vec2(0.5,0.5))*size);
-            r -= v_size/2;
-            return r;
-        }
-
-        // ----------------
-        float arrow_right(vec2 P, float size)
-        {
-            float r1 = abs(P.x -.50)*size + abs(P.y -.5)*size - v_size/2;
-            float r2 = abs(P.x -.25)*size + abs(P.y -.5)*size - v_size/2;
-            float r = max(r1,-r2);
-            return r;
-        }
-
-        // ----------------
-        float ring(vec2 P, float size)
-        {
-            float r1 = length((gl_PointCoord.xy - vec2(0.5,0.5))*size) - v_size/2;
-            float r2 = length((gl_PointCoord.xy - vec2(0.5,0.5))*size) - v_size/4;
-            float r = max(r1,-r2);
-            return r;
-        }
-
-        // ----------------
-        float clober(vec2 P, float size)
-        {
-            const float PI = 3.14159265358979323846264;
-            const float t1 = -PI/2;
-            const vec2  c1 = 0.2*vec2(cos(t1),sin(t1));
-            const float t2 = t1+2*PI/3;
-            const vec2  c2 = 0.2*vec2(cos(t2),sin(t2));
-            const float t3 = t2+2*PI/3;
-            const vec2  c3 = 0.2*vec2(cos(t3),sin(t3));
-
-            float r1 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c1)*size);
-            r1 -= v_size/3;
-            float r2 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c2)*size);
-            r2 -= v_size/3;
-            float r3 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c3)*size);
-            r3 -= v_size/3;
-            float r = min(min(r1,r2),r3);
-            return r;
-        }
-
-        // ----------------
-        float square(vec2 P, float size)
-        {
-            float r = max(abs(gl_PointCoord.x -.5)*size,
-                          abs(gl_PointCoord.y -.5)*size);
-            r -= v_size/2;
-            return r;
-        }
-
-        // ----------------
-        float diamond(vec2 P, float size)
-        {
-            float r = abs(gl_PointCoord.x -.5)*size + abs(gl_PointCoord.y -.5)*size;
-            r -= v_size/2;
-            return r;
-        }
-
-        // ----------------
-        float vbar(vec2 P, float size)
-        {
-            float r1 = max(abs(gl_PointCoord.x -.75)*size,
-                           abs(gl_PointCoord.x -.25)*size);
-            float r3 = max(abs(gl_PointCoord.x -.5)*size,
-                           abs(gl_PointCoord.y -.5)*size);
-            float r = max(r1,r3);
-            r -= v_size/2;
-            return r;
-        }
-
-        // ----------------
-        float hbar(vec2 P, float size)
-        {
-            float r2 = max(abs(gl_PointCoord.y -.75)*size,
-                           abs(gl_PointCoord.y -.25)*size);
-            float r3 = max(abs(gl_PointCoord.x -.5)*size,
-                           abs(gl_PointCoord.y -.5)*size);
-            float r = max(r2,r3);
-            r -= v_size/2;
-            return r;
-        }
-
-        // ----------------
-        float cross(vec2 P, float size)
-        {
-            float r1 = max(abs(gl_PointCoord.x -.75)*size,
-                           abs(gl_PointCoord.x -.25)*size);
-            float r2 = max(abs(gl_PointCoord.y -.75)*size,
-                           abs(gl_PointCoord.y -.25)*size);
-            float r3 = max(abs(gl_PointCoord.x -.5)*size,
-                           abs(gl_PointCoord.y -.5)*size);
-            float r = max(min(r1,r2),r3);
-            r -= v_size/2;
-            return r;
-        }
-
-
-        // Main
-        // ------------------------------------
-        void main()
-        {
-            float size = v_size +2*(v_linewidth + 1.5*v_antialias);
-            float t = v_linewidth/2.0-v_antialias;
-
-            float r = disc(gl_PointCoord, size);
-            // float r = square(gl_PointCoord, size);
-            // float r = ring(gl_PointCoord, size);
-            // float r = arrow_right(gl_PointCoord, size);
-            // float r = diamond(gl_PointCoord, size);
-            // float r = cross(gl_PointCoord, size);
-            // float r = clober(gl_PointCoord, size);
-            // float r = hbar(gl_PointCoord, size);
-            // float r = vbar(gl_PointCoord, size);
-
-
-            float d = abs(r) - t;
-            if( r > (v_linewidth/2.0+v_antialias))
-            {
-                discard;
-            }
-            else if( d < 0.0 )
-            {
-               gl_FragColor = v_fg_color;
-            }
-            else
-            {
-                float alpha = d/v_antialias;
-                alpha = exp(-alpha*alpha);
-                if (r > 0)
-                    gl_FragColor = vec4(v_fg_color.rgb, alpha*v_fg_color.a);
-                else
-                    gl_FragColor = mix(v_bg_color, v_fg_color, alpha);
-            }
-        }
-        """
-
         # Prepare canvas
-        self.canvas = app.Canvas(keys='interactive', show=False)
-        self.canvas.size = [600, 400]
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
         self.canvas.measure_fps()
 
-        gloo.set_state('translucent', clear_color='white')
-        gloo.gl.use_gl('gl2 debug')
-
-        # Prepare canvas.program and related parameters
-        self.canvas.program = gloo.Program(vert, frag)
-        self.model = np.eye(4, dtype=np.float32)
-        self.projection = np.eye(4, dtype=np.float32)
-
         # Set up a viewbox to display the image with interactive pan/zoom
-        self.view = np.eye(4, dtype=np.float32)
-        self.translate = 20  # This is used to set the initial size :-)
-        self.view = translate((0, 0, -self.translate))  # Is there anything like self.view.translate?
+        self.view = self.canvas.central_widget.add_view()
+        self.view.border_color = 'red'
+        self.view.parent = self.canvas.scene
+        self.view.camera = 'turntable'  # or try 'arcball'
 
-        # Prepare data and subsets
         self.data = None
-        self.bind_data = None
+        self.axes_names = None
+        self._current_array = None
 
-        # Set parameters for timer
-        self.timer_dt = 1.0/60
-        self.timer_t = 0.0
-        self.timer = app.Timer(self.timer_dt)
-        self.timer.connect(self.on_timer)
+        self.vol_visual = None
 
-        # Prepare for mouse event and rotate
-        self.is_dragging = False
-        self.is_mouse_pressed = False
-        self.theta, self.phi = 0, 0
+        # Add a 3D axis to keep us oriented
+        self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
 
-        self.prev_phi = 0.0
-        self.prev_theta = 0.0
-        self.prev_timer_t = 0
+        self.widget_axis_scale = [1, 1, 1]
 
-        self.rotate_theta_speed = 0.0
-        self.rotate_phi_speed = 0.0
+        # Set up default colormap
+        self.color_map = get_colormap('hot')
 
-        # Connect events
-        self.canvas.events.mouse_wheel.connect(self.on_mouse_wheel)
-        self.canvas.events.draw.connect(self.on_draw)
-        self.canvas.events.resize.connect(self.on_resize)
-        self.canvas.events.mouse_press.connect(self.on_mouse_press)
-        self.canvas.events.mouse_move.connect(self.on_mouse_move)
-        self.canvas.events.mouse_release.connect(self.on_mouse_release)
+        self._shown_data = None
 
     @property
     def data(self):
@@ -280,7 +55,6 @@ class QtScatVispyWidget(QtGui.QWidget):
             self.options_widget.set_valid_components([c.label for c in data.component_ids()])
             self._refresh()
 
-
     @property
     def components(self):
         if self.data is None:
@@ -292,116 +66,41 @@ class QtScatVispyWidget(QtGui.QWidget):
                           self.data[self.options_widget.ui.SizeComboBox.currentText()]]
             return components
 
-    # TODO: Add subset functionality
+    def _refresh(self):
+        """
+        This method can be called if the options widget is updated.
+        """
+        if self.data is None:
+            return
+            array = self.component
+            self.update()
+
     def set_subsets(self, subsets):
         self.subsets = subsets
 
-    # TODO: Implement the size algorithm
-    # Set canvas.program according to loading_data
     def set_program(self):
         if self.data is None:
             return None
         else:
             if not hasattr(self, 'components'): return
             n = len(self.components[3])
-            P = np.zeros((n,3), dtype=np.float32)
+            P = np.zeros((n, 3), dtype=np.float32)
 
-            X, Y, Z =  P[:,0],P[:,1],P[:,2]
+            X, Y, Z = P[:, 0], P[:, 1], P[:, 2]
             X[...] = self.components[0]
             Y[...] = self.components[1]
             Z[...] = self.components[2]
 
             # Dot size determination according to the mass - *2 for larger size
             S = np.zeros(n)
-            S[...] = 5* self.components[3]**(1./3)/1.e1
+            # size = np.ones((n, 1))
+            # size[:, 0] = self.components[3]
+            S[...] = self.components[3] ** (1. / 3) / 1.e1
 
-            # Wrap the data into a package
-            data = np.zeros(n, [('a_position', np.float32, 3),
-                                ('a_size',     np.float32, 1),
-                                ('a_bg_color', np.float32, 4),
-                                ('a_fg_color', np.float32, 4)])
+            # create scatter object and fill in the data
+            scatter = scene.visuals.Markers()
+            scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
 
-            data['a_bg_color'] = np.random.uniform(0.85, 1.00, (n, 4))
-            data['a_fg_color'] = 0, 0, 0, 1
-            data['a_position'] = P
-            data['a_size'] = S
-
-            u_linewidth = 1.0
-            u_antialias = 1.0
-
-            self.bind_data = data
-            self.canvas.program.bind(gloo.VertexBuffer(self.bind_data))
-
-            self.canvas.program['u_linewidth'] = u_linewidth
-            self.canvas.program['u_antialias'] = u_antialias
-            self.canvas.program['u_model'] = self.model
-            self.canvas.program['u_view'] = self.view
-            self.canvas.program['u_size'] = 5 / self.translate
-
-            self.timer.start()
+            self.view.add(scatter)
             self.canvas.update()
 
-    # TODO: to be implemented
-    def _refresh(self):
-        if self.data is None:
-            return
-        self.update()
-
-    def on_timer(self, event):
-        self.timer_t += self.timer_dt # keep track on the current time
-        self.theta += self.rotate_theta_speed
-        self.phi += self.rotate_phi_speed
-        self.model = np.eye(4, dtype=np.float32)
-        self.model = np.dot(rotate(self.theta, (0, 0, 1)),
-                            rotate(self.phi, (0, 1, 0)))
-        self.canvas.program['u_model'] = self.model
-        self.update()
-
-    # Set projection for canvas.program
-    def set_projection(self):
-        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
-        self.projection = perspective(45.0, self.canvas.size[0] /
-                                      float(self.canvas.size[1]), 1.0, 1000.0)
-        self.canvas.program['u_projection'] = self.projection
-
-    def on_resize(self, event):
-        self.set_projection()
-
-    def on_draw(self, event):
-        gloo.gl.glClear(gloo.gl.GL_COLOR_BUFFER_BIT | gloo.gl.GL_DEPTH_BUFFER_BIT)
-        self.canvas.program.draw(gloo.gl.GL_POINTS)
-
-    def on_mouse_wheel(self, event):
-        self.translate -= event.delta[1]
-        self.translate = max(2, self.translate)
-        self.view = translate((0, 0, -self.translate))
-
-        self.canvas.program['u_view'] = self.view
-        self.canvas.program['u_size'] = 5 / self.translate
-        self.canvas.update()
-
-    def on_mouse_press(self, event):
-        self.canvas.prev_cursor_x, self.canvas.prev_cursor_y = event.pos
-        self.canvas.dragging_marked = False
-        self.is_mouse_pressed = True
-
-    def on_mouse_move(self, event):
-        if event.is_dragging:
-            self.is_dragging = True
-            x, y = event.pos
-            dx = x-self.canvas.prev_cursor_x
-            dy = y-self.canvas.prev_cursor_y
-            self.phi += float(dx)/x*180
-            self.theta += float(dy)/y*180
-
-            self.model = np.dot(rotate(self.theta, (0, 0, 1)),
-                                rotate(self.phi, (0, 1, 0)))
-
-            self.canvas.prev_cursor_x, self.canvas.prev_cursor_y = event.pos
-            self.prev_timer_t = self.timer_t
-            self.canvas.program['u_model'] = self.model
-            self.canvas.update()
-
-    def on_mouse_release(self, event):
-        self.is_dragging = False
-        self.is_mouse_pressed = False

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -1,0 +1,454 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+import numpy as np
+from glue.external.qt import QtGui
+from vispy import scene, app, gloo
+from vispy import gloo
+from vispy.util.transforms import perspective, translate, rotate
+
+
+__all__ = ['QtScatVispyWidget']
+
+
+
+class QtScatVispyWidget(QtGui.QWidget):
+
+    def __init__(self, parent=None):
+
+        super(QtScatVispyWidget, self).__init__(parent=parent)
+
+        vert = """
+        #version 120
+
+        // Uniforms
+        // ------------------------------------
+        uniform mat4 u_model;
+        uniform mat4 u_view;
+        uniform mat4 u_projection;
+        uniform float u_linewidth;
+        uniform float u_antialias;
+        uniform float u_size;
+
+        // Attributes
+        // ------------------------------------
+        attribute vec3  a_position;
+        attribute vec4  a_fg_color;
+        attribute vec4  a_bg_color;
+        attribute float a_size;
+
+        // Varyings
+        // ------------------------------------
+        varying vec4 v_fg_color;
+        varying vec4 v_bg_color;
+        varying float v_size;
+        varying float v_linewidth;
+        varying float v_antialias;
+
+        void main (void) {
+            v_size = a_size * u_size;
+            v_linewidth = u_linewidth;
+            v_antialias = u_antialias;
+            v_fg_color  = a_fg_color;
+            v_bg_color  = a_bg_color;
+            gl_Position = u_projection * u_view * u_model * vec4(a_position,1.0);
+            gl_PointSize = v_size + 2*(v_linewidth + 1.5*v_antialias);
+        }
+        """
+
+        frag = """
+        #version 120
+
+        // Constants
+        // ------------------------------------
+
+
+        // Varyings
+        // ------------------------------------
+        varying vec4 v_fg_color;
+        varying vec4 v_bg_color;
+        varying float v_size;
+        varying float v_linewidth;
+        varying float v_antialias;
+
+        // Functions
+        // ------------------------------------
+
+        // ----------------
+        float disc(vec2 P, float size)
+        {
+            float r = length((P.xy - vec2(0.5,0.5))*size);
+            r -= v_size/2;
+            return r;
+        }
+
+        // ----------------
+        float arrow_right(vec2 P, float size)
+        {
+            float r1 = abs(P.x -.50)*size + abs(P.y -.5)*size - v_size/2;
+            float r2 = abs(P.x -.25)*size + abs(P.y -.5)*size - v_size/2;
+            float r = max(r1,-r2);
+            return r;
+        }
+
+        // ----------------
+        float ring(vec2 P, float size)
+        {
+            float r1 = length((gl_PointCoord.xy - vec2(0.5,0.5))*size) - v_size/2;
+            float r2 = length((gl_PointCoord.xy - vec2(0.5,0.5))*size) - v_size/4;
+            float r = max(r1,-r2);
+            return r;
+        }
+
+        // ----------------
+        float clober(vec2 P, float size)
+        {
+            const float PI = 3.14159265358979323846264;
+            const float t1 = -PI/2;
+            const vec2  c1 = 0.2*vec2(cos(t1),sin(t1));
+            const float t2 = t1+2*PI/3;
+            const vec2  c2 = 0.2*vec2(cos(t2),sin(t2));
+            const float t3 = t2+2*PI/3;
+            const vec2  c3 = 0.2*vec2(cos(t3),sin(t3));
+
+            float r1 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c1)*size);
+            r1 -= v_size/3;
+            float r2 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c2)*size);
+            r2 -= v_size/3;
+            float r3 = length((gl_PointCoord.xy- vec2(0.5,0.5) - c3)*size);
+            r3 -= v_size/3;
+            float r = min(min(r1,r2),r3);
+            return r;
+        }
+
+        // ----------------
+        float square(vec2 P, float size)
+        {
+            float r = max(abs(gl_PointCoord.x -.5)*size,
+                          abs(gl_PointCoord.y -.5)*size);
+            r -= v_size/2;
+            return r;
+        }
+
+        // ----------------
+        float diamond(vec2 P, float size)
+        {
+            float r = abs(gl_PointCoord.x -.5)*size + abs(gl_PointCoord.y -.5)*size;
+            r -= v_size/2;
+            return r;
+        }
+
+        // ----------------
+        float vbar(vec2 P, float size)
+        {
+            float r1 = max(abs(gl_PointCoord.x -.75)*size,
+                           abs(gl_PointCoord.x -.25)*size);
+            float r3 = max(abs(gl_PointCoord.x -.5)*size,
+                           abs(gl_PointCoord.y -.5)*size);
+            float r = max(r1,r3);
+            r -= v_size/2;
+            return r;
+        }
+
+        // ----------------
+        float hbar(vec2 P, float size)
+        {
+            float r2 = max(abs(gl_PointCoord.y -.75)*size,
+                           abs(gl_PointCoord.y -.25)*size);
+            float r3 = max(abs(gl_PointCoord.x -.5)*size,
+                           abs(gl_PointCoord.y -.5)*size);
+            float r = max(r2,r3);
+            r -= v_size/2;
+            return r;
+        }
+
+        // ----------------
+        float cross(vec2 P, float size)
+        {
+            float r1 = max(abs(gl_PointCoord.x -.75)*size,
+                           abs(gl_PointCoord.x -.25)*size);
+            float r2 = max(abs(gl_PointCoord.y -.75)*size,
+                           abs(gl_PointCoord.y -.25)*size);
+            float r3 = max(abs(gl_PointCoord.x -.5)*size,
+                           abs(gl_PointCoord.y -.5)*size);
+            float r = max(min(r1,r2),r3);
+            r -= v_size/2;
+            return r;
+        }
+
+
+        // Main
+        // ------------------------------------
+        void main()
+        {
+            float size = v_size +2*(v_linewidth + 1.5*v_antialias);
+            float t = v_linewidth/2.0-v_antialias;
+
+            float r = disc(gl_PointCoord, size);
+            // float r = square(gl_PointCoord, size);
+            // float r = ring(gl_PointCoord, size);
+            // float r = arrow_right(gl_PointCoord, size);
+            // float r = diamond(gl_PointCoord, size);
+            // float r = cross(gl_PointCoord, size);
+            // float r = clober(gl_PointCoord, size);
+            // float r = hbar(gl_PointCoord, size);
+            // float r = vbar(gl_PointCoord, size);
+
+
+            float d = abs(r) - t;
+            if( r > (v_linewidth/2.0+v_antialias))
+            {
+                discard;
+            }
+            else if( d < 0.0 )
+            {
+               gl_FragColor = v_fg_color;
+            }
+            else
+            {
+                float alpha = d/v_antialias;
+                alpha = exp(-alpha*alpha);
+                if (r > 0)
+                    gl_FragColor = vec4(v_fg_color.rgb, alpha*v_fg_color.a);
+                else
+                    gl_FragColor = mix(v_bg_color, v_fg_color, alpha);
+            }
+        }
+        """
+
+
+        # Initialize
+        # gloo.set_state('translucent', clear_color='black')
+        # gloo.glDisable(gloo.GL_DEPTH_TEST)
+        # gloo.glEnable(gloo.GL_BLEND)
+        # gloo.glBlendFunc(gloo.GL_SRC_ALPHA, gloo.GL_ONE) #_MINUS_SRC_ALPHA)
+
+        # Prepare canvas
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
+        self.canvas.size = [600, 400]
+        self.canvas.measure_fps()
+
+        # Set up a viewbox to display the image with interactive pan/zoom
+        self.view = self.canvas.central_widget.add_view()
+        self.view.border_color = 'red'
+        self.view.parent = self.canvas.scene
+
+
+
+        # If you want to use gloo without vispy.app, use a gloo.context.FakeCanvas.
+        # fake_can = gloo.context.FakeCanvas()
+        # fake_can.flush()
+        gloo.set_state('translucent', clear_color='white')
+
+        self.program = gloo.Program(vert, frag)
+        # self.program = gloo.Program(self.VERT_SHADER, self.FRAG_SHADER)
+        self.model = np.eye(4,dtype=np.float32)
+        self.projection = np.eye(4,dtype=np.float32)
+        self.theta, self.phi = 0,0
+
+        self.translate = 20  # For cute Penny: this is used to set the initial size :-)
+        self.view = translate((0, 0, -self.translate)) #Is there anything like self.view.translate?
+
+        self.data = None
+        '''self.zoom_size = 0
+        self.zoom_text_visual = self.add_text_visual()
+        self.zoom_timer = app.Timer(0.2, connect=self.on_timer, start=False)
+
+        # Add a 3D axis to keep us oriented
+        self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
+        self.widget_axis_scale = [1, 1, 1]'''
+
+        # self.program.bind(gloo.VertexBuffer(data))
+
+        # self.program['u_size'] = 5./self.translate
+        # self.program['u_model'] = self.model
+        # self.program['u_view'] = self.view
+
+
+
+
+        self.timer_dt = 1.0/60
+        self.timer_t = 0.0
+        self.timer = app.Timer(self.timer_dt)
+        self.timer.connect(self.on_timer)
+
+        self.is_dragging = False
+        self.is_mouse_pressed = False
+
+        self.prev_phi = 0.0
+        self.prev_theta = 0.0
+        self.prev_timer_t = 0
+
+        self.rotate_theta_speed = 0.0
+        self.rotate_phi_speed = 0.0
+
+
+        # Connect events
+        self.canvas.events.mouse_wheel.connect(self.on_mouse_wheel)
+        self.canvas.events.draw.connect(self.on_draw)
+
+        # self.canvas.events.resize.connect(self.on_resize)
+
+        # gl.glClearColor(0,0,0,1)
+        # gl.glDisable(gl.GL_DEPTH_TEST)
+        # gl.glEnable(gl.GL_BLEND)
+        # gl.glBlendFunc (gl.GL_SRC_ALPHA, gl.GL_ONE)
+
+    # def on_initialize(self, event):
+    #     gl.glClearColor(0,0,0,1)
+    #     gl.glDisable(gl.GL_DEPTH_TEST)
+    #     gl.glEnable(gl.GL_BLEND)
+    #     gl.glBlendFunc (gl.GL_SRC_ALPHA, gl.GL_ONE) #_MINUS_SRC_ALPHA)
+    #     Start the timer upon initialization.
+        # self.timer.start()
+        # print('Timer.start')
+
+    def set_data(self, data):
+        self.data = data
+
+    # def set_frame_data(self,data):
+    #     self.program.bind(gloo.VertexBuffer(data))
+
+        print('Data bind!')
+
+    def set_subsets(self, subsets):
+        self.subsets = subsets
+
+    def set_program(self):
+        if self.data is None:
+            return None
+        else:
+            n = len(self.data.get_component('x_gal').data)
+            P = np.zeros((n,3), dtype=np.float32)
+
+            X, Y, Z =  P[:,0],P[:,1],P[:,2]
+            X[...] = self.data.get_component('x_gal').data
+            Y[...] = self.data.get_component('y_gal').data
+            Z[...] = self.data.get_component('z_gal').data
+
+            # Dot size determination according to the mass - *2 for larger size
+            S = np.zeros(n)
+            S[...] = 5* self.data.get_component('mass').data**(1./3)/1.e1
+
+
+            # Wrap the data into a package
+            data = np.zeros(n, [('a_position', np.float32, 3),
+                                ('a_size',     np.float32, 1),
+                                ('a_bg_color', np.float32, 4),
+                                ('a_fg_color', np.float32, 4)])
+
+            data['a_bg_color'] = np.random.uniform(0.85, 1.00, (n, 4))
+            data['a_fg_color'] = 0, 0, 0, 1
+            data['a_position'] = P
+            data['a_size'] = S
+
+            u_linewidth = 1.0
+            u_antialias = 1.0
+
+            self.program.bind(gloo.VertexBuffer(data))
+
+            self.program['u_linewidth'] = u_linewidth
+            self.program['u_antialias'] = u_antialias
+            self.program['u_model'] = self.model
+            self.program['u_view'] = self.view
+            self.program['u_size'] = 5 / self.translate
+
+            print('data is:', data)
+            self.timer.start()
+            # return data
+
+    def on_key_press(self, event):
+        if event.text == ' ':
+            if self.timer.running:
+                self.timer.stop()
+                print('Press enter!')
+            else:
+                self.timer.start()
+
+    def on_timer(self, event):
+        self.timer_t += self.timer_dt # keep track on the current time
+        self.theta += self.rotate_theta_speed
+        self.phi += self.rotate_phi_speed
+        self.model = np.eye(4, dtype=np.float32)
+        self.model = np.dot(rotate(self.theta, (0, 0, 1)),
+                            rotate(self.phi, (0, 1, 0)))
+        self.program['u_model'] = self.model
+        self.update()
+
+    def set_projection(self):
+        # width, height = event.size
+        # gloo.glViewport(0, 0, width, height)
+        # self.projection = perspective( 45.0, width/float(height), 1.0, 1000.0 )
+        # self.program['u_projection'] = self.projection
+        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
+        self.projection = perspective(45.0, self.canvas.size[0] /
+                                      float(self.canvas.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
+
+    def on_mouse_wheel(self, event):
+        self.translate -= event.delta[1]
+        self.translate = max(2, self.translate)
+        self.view = translate((0, 0, -self.translate))
+
+        self.program['u_view'] = self.view
+        self.program['u_size'] = 5 / self.translate
+        self.update()
+
+    def on_draw(self, event):
+        # gloo.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+        gloo.clear()
+        # gloo.clear()
+        self.program.draw(mode='points')
+
+    '''def apply_zoom(self):
+        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection'''
+
+    # def on_paint(self, event):
+    #     gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+    #     self.program.draw(gl.GL_POINTS)
+
+    '''def add_volume_visual(self):
+
+        # TODO: need to implement the visualiation of the subsets in this method
+
+        vol_data = self.get_data()
+        # Create the volume visual and give default settings
+        vol_visual = scene.visuals.Volume(vol_data, parent=self.view.scene, threshold=0.1, method='mip',
+                                       emulate_texture=self.emulate_texture)
+        # volume1.cmap = self.color_map
+
+        trans = (-vol_data.shape[2]/2, -vol_data.shape[1]/2, -vol_data.shape[0]/2)
+        _axis_scale = (vol_data.shape[2], vol_data.shape[1], vol_data.shape[0])
+        vol_visual.transform = scene.STTransform(translate=trans)
+
+        self.axis.transform = scene.STTransform(translate=trans, scale=_axis_scale)
+
+        self.vol_visual = vol_visual
+        self.widget_axis_scale = self.axis.transform.scale
+
+    def add_text_visual(self):
+        # Create the text visual to show zoom scale
+        text = scene.visuals.Text('', parent=self.canvas.scene, color='white', bold=True, font_size=16)
+        text.pos = [40, self.canvas.size[1]-40]
+        return text
+
+    def on_timer(self, event):
+        self.zoom_text_visual.color = [1, 1, 1, float((7-event.iteration) % 8)/8]
+        self.canvas.update()
+
+    def on_resize(self, event):
+        self.zoom_text_visual.pos = [40, self.canvas.size[1] - 40]
+
+    def on_mouse_wheel(self, event):
+        if self.view.camera.distance is None:
+            self.view.camera.distance = 10.0
+        if self.view.camera is self.turntableCamera:
+            self.zoom_size = self.ori_distance / self.view.camera.distance
+            # self.zoom_size += event.delta[1]
+            self.zoom_text_visual.text = 'X %s' % round(self.zoom_size, 1)
+            self.zoom_timer.start(interval=0.2, iterations=8)
+        # TODO: add a bound for fly_mode mouse_wheel'''

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -317,6 +317,10 @@ class QtScatVispyWidget(QtGui.QWidget):
             print('data is:', data)
             self.timer.start()
 
+    # TODO: to be implemented
+    def _refresh(self):
+        self.update()
+
     def on_timer(self, event):
         self.timer_t += self.timer_dt # keep track on the current time
         self.theta += self.rotate_theta_speed
@@ -338,12 +342,8 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.set_projection()
 
     def on_draw(self, event):
-        # gloo.clear()
-        # self.canvas.program.draw(mode='points')
         gloo.gl.glClear(gloo.gl.GL_COLOR_BUFFER_BIT | gloo.gl.GL_DEPTH_BUFFER_BIT)
-        # gloo.clear(color=True, depth=True)
         self.canvas.program.draw(gloo.gl.GL_POINTS)
-        # self.canvas.update()
 
     def on_paint(self, event):
         gloo.gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -201,9 +201,9 @@ class QtScatVispyWidget(QtGui.QWidget):
             S = np.zeros(n)
             # size = np.ones((n, 1))
             # size[:, 0] = self.components[3]
-            # S[...] = 100* self.components[3] ** (1. / 3) / 1.e1
-            S[...] = self.components[3]
-            print('size:', S)
+            S[...] = self.components[3] ** (1. / 3) / 1.e1
+            # S[...] = self.components[3]
+            # print('size:', S)
 
             scatter_color =Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
 

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -145,7 +145,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
             if self.trans_flag == 0:
                 # Set transform for axis and camera
-                self.set_transform()
+                self.set_transform([self.components[0], self.components[0], self.components[0]], self.components[3])
             # self.scatter.transform = scene.STTransform(translate=(), scale=stretch_scale)
 
             # set clim value
@@ -179,7 +179,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         # Save this for refresh
         self.scat_visual_data = [P, scatter_color, S]
 
-        self.set_transform()
+        self.set_transform([self.components[0], self.components[1], self.components[2]], self.components[3])
 
         # set clim value
         self._update_clim()
@@ -187,7 +187,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
     def _refresh(self):
         """
-        This method can be called if the stretch sliders are updated.
+        This method can be called if the stretch & opacity sliders are updated.
         """
         if self.data is None:
             return
@@ -208,6 +208,9 @@ class QtScatVispyWidget(QtGui.QWidget):
             scatter_color = Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
             self.scat_visual.set_data(new_P, symbol='disc', edge_color=None,
                                       face_color=scatter_color, size=new_S)
+
+            # Update the transform according to the stretch made here
+            self.set_transform([new_P[:, 0], new_P[:, 1], new_P[:, 2]], new_S)
             # self.scat_visual_data = [new_P, scatter_color, new_S]
 
     # Set the clim dataset and apply the new dataset to the current scatter visual
@@ -262,12 +265,12 @@ class QtScatVispyWidget(QtGui.QWidget):
 
     # Set the transform of axis and distance of turntable camera according to the scale of the data
     # After clicking the 'apply'
-    def set_transform(self):
+    def set_transform(self, position, size):
         # Get the min and max of each axis
-        xmin, xmax = self.get_minmax(self.components[0])
-        ymin, ymax = self.get_minmax(self.components[1])
-        zmin, zmax = self.get_minmax(self.components[2])
-        sizemin, sizemax = self.get_minmax(self.components[3])
+        xmin, xmax = self.get_minmax(position[0])
+        ymin, ymax = self.get_minmax(position[1])
+        zmin, zmax = self.get_minmax(position[2])
+        sizemin, sizemax = self.get_minmax(size)
         _axis_scale = (sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1)
         trans = (-(xmax+xmin)/2.0, -(ymax+ymin)/2.0, -(zmax+zmin)/2.0)
         # stretch_scale = (3.0, 5.0, 1.0)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -57,55 +57,68 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.canvas.events.resize.connect(self.on_resize)
 
     def add_fila(self):
-        vol = np.genfromtxt('/Users/penny/Works/filaments_vispy/Penny_Bones_Updated.txt',
-                            delimiter='\t', dtype=None)
+        vol = np.genfromtxt('/Users/penny/Works/filaments_vispy/Penny_Bones_Updated.txt', delimiter='\t', dtype=None)
         fila = []
-        # fila's structure is [filament_name, glong, glat, distance_kpc, radius_pc]
-        for n in np.arange(0, vol.shape[0]-1, 1):
+        # fila's structure is [filament_name, glong, glat, gdistance_kpc, radius_pc]
+        for n in np.arange(0, vol.shape[0], 1):
             fila.append([vol[n][0], vol[n][1], vol[n][2], vol[n][3], vol[n][4]])
         filament_name = []
         filament_name.append(vol[0][0])
         i=0
         points = []
+        one_fila = []
+        new_fila = []
+        # Sort the lbd data through longitude
         for each_line in fila:
             if each_line[0] == filament_name[i]:
-                # add pos to the points
-                # l, b, d = radians(each_line[1]), radians(each_line[2]), each_line[3]
-                l, b, d = each_line[1], each_line[2], each_line[3]
-                # Using equations (7) & (8) to for the following calculation
-                # Galactic Coordinate to Solar center Cartesian Coordinate
-                # points.append([d*degrees(cos(l))*degrees(cos(b)), d*degrees(sin(l))*degrees(cos(b)), d*degrees(sin(b))])
-                points.append([d*cos(l)*cos(b), d*sin(l)*cos(b), d*sin(b)])
-                # Galactic Coordinate to Galactic center Cartesian Coordinate
-                '''thita = asin(0.025/8.0)
-                x_gal = 8.0*cos(thita) - d*(cos(l)*cos(b)*cos(thita)+sin(b)*sin(thita))
-                y_gal = -d*sin(l)*cos(b)
-                z_gal = 8.0*sin(thita)-d*(cos(l)*cos(b)*sin(thita)-sin(b)*cos(thita))
-                points.append([x_gal, y_gal, z_gal])'''
-                radius = each_line[4]
-                print('============')
-                print('points', points)
-                # print('x_gal, y_gal, z_gal:', x_gal, y_gal, z_gal)
+                one_fila.append(each_line)
             else:
-                # Draw points
-
-                l = scene.visuals.Tube(points,
-                                       color='yellow',
-                                       shading='flat',
-                                       tube_points=8,
-                                       radius=float(radius)/10.0)
-                self.view.add(l)
-                points = []
-                # redefine the points
-                i += 1
+                sort_fila = np.sort(one_fila, axis=0)
+                new_fila.append(sort_fila)
+                one_fila = []
+                one_fila.append(each_line)
+                i=i+1
                 filament_name.append(each_line[0])
+        sort_fila = np.sort(one_fila, axis=0)
+        new_fila.append(sort_fila)
 
+        i = 0
+        new_filament_name = []
+        new_filament_name.append(vol[0][0])
+
+        for each_fila in new_fila:
+            for each_new_line in each_fila:
+                if each_new_line[0] == new_filament_name[i]:
+                    l=radians(float(each_new_line[1]))
+                    b=radians(float(each_new_line[2]))
+                    d=float(each_new_line[3])
+                    points.append([d*cos(l)*cos(b), d*sin(l)*cos(b), d*sin(b)])
+                    # Sort the points according to the first dimension
+                    radius = float(each_new_line[4])/1000.0
+                else:
+                    l = scene.visuals.Tube(points,
+                                    color='yellow',
+                                    shading='flat',
+                                    tube_points=8,
+                                    radius=float(radius))
+                    '''print('=========')
+                    print('radius:', radius)
+                    print('sort_points:', sort_points)'''
+                    self.view.add(l)
+                    points = []
+                    l=radians(float(each_new_line[1]))
+                    b=radians(float(each_new_line[2]))
+                    d=float(each_new_line[3])
+                    points.append([d*cos(l)*cos(b), d*sin(l)*cos(b), d*sin(b)])
+                    # redefine the points
+                    i=i+1
+                    new_filament_name.append(each_new_line[0])
         # Draw points
         l = scene.visuals.Tube(points,
                         color='yellow',
                         shading='flat',
                         tube_points=8,
-                        radius=float(radius)/10.0)
+                        radius=float(radius))
         self.view.add(l)
         self.canvas.update()
 

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -6,6 +6,9 @@ import numpy as np
 from glue.external.qt import QtGui
 from vispy import scene, app
 from vispy.color import get_colormap, Color
+# from vispy.visuals.transforms import (STTransform, MatrixTransform,\
+#                                       ChainTransform, TransformSystem)
+
 
 __all__ = ['QtScatVispyWidget']
 
@@ -33,15 +36,21 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.scatter = scene.visuals.Markers()
 
         # Add a grid plane
-        self.grid = scene.visuals.GridLines(scale=(500, 500))
+        self.grid = scene.visuals.GridLines(parent=self.view)
+        # affine = scene.transforms.MatrixTransform()
+        # trans = self.view.transform
+        # self.grid.transform = STTransform(translate=(0, 1), scale=(0.5, 0.5))
+
+        # trans = self.grid.transform
+
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
-
+        print('==========')
+        print('axis tranform', self.axis.transform)
         self.widget_axis_scale = [1, 1, 1]
 
-        # Set up default colormap
-        self.color_map = get_colormap('hot')
+        # trans.scale = self.axis.transform.scale
 
         self._shown_data = None
 
@@ -155,8 +164,10 @@ class QtScatVispyWidget(QtGui.QWidget):
         # Dot size determination according to the mass - *2 for larger size
         S = np.zeros(n)
         S[...] = _clim_components[3] ** (1. / 3) / 1.e1
+        scatter_color =Color(self.options_widget.color, self.options_widget.opacity/100.0)
+
         # Reset the data for scatter visual display
-        self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=self.options_widget.color, size=S)
+        self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)
         self.canvas.update()
 
     def _update_clim(self):

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -289,7 +289,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
             # Dot size determination according to the mass - *2 for larger size
             S = np.zeros(n)
-            S[...] = 5* self.data.get_component('mass').data**(1./3)/1.e5
+            S[...] = 5* self.data.get_component('mass').data**(1./3)/1.e1
 
 
             # Wrap the data into a package
@@ -338,8 +338,16 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.set_projection()
 
     def on_draw(self, event):
-        gloo.clear()
-        self.canvas.program.draw(mode='points')
+        # gloo.clear()
+        # self.canvas.program.draw(mode='points')
+        gloo.gl.glClear(gloo.gl.GL_COLOR_BUFFER_BIT | gloo.gl.GL_DEPTH_BUFFER_BIT)
+        # gloo.clear(color=True, depth=True)
+        self.canvas.program.draw(gloo.gl.GL_POINTS)
+        # self.canvas.update()
+
+    def on_paint(self, event):
+        gloo.gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+        self.program.draw(gloo.gl.GL_POINTS)
 
     def on_mouse_wheel(self, event):
         self.translate -= event.delta[1]

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -7,6 +7,8 @@ from glue.external.qt import QtGui
 from vispy import scene, app
 from vispy.color import get_colormap, Color
 from math import cos, sin, asin, radians, degrees
+from vispy.scene.cameras import MagnifyCamera, Magnify1DCamera
+
 from vispy.visuals import transforms
 
 
@@ -26,7 +28,9 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.view = self.canvas.central_widget.add_view()
         self.view.border_color = 'red'
         self.view.parent = self.canvas.scene
-        self.view.camera = 'turntable'  # or try 'arcball'
+        self.turn_cam = scene.cameras.TurntableCamera(parent=self.view.scene, name='Turntable')
+        self.mag_cam = MagnifyCamera()
+        self.view.camera = self.turn_cam # or try 'arcball'
 
         self.data = None
         self.axes_names = None
@@ -94,7 +98,7 @@ class QtScatVispyWidget(QtGui.QWidget):
                     d=float(each_new_line[3])
                     points.append([d*cos(l)*cos(b), d*sin(l)*cos(b), d*sin(b)])
                     # Sort the points according to the first dimension
-                    radius = float(each_new_line[4])/1000.0
+                    radius = float(each_new_line[4])/100.0
                 else:
                     l = scene.visuals.Tube(points,
                                     color='yellow',

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -373,7 +373,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.program['u_model'] = self.model
         self.update()
 
-    '''def set_projection(self):
+    def set_projection(self):
         # width, height = event.size
         # gloo.glViewport(0, 0, width, height)
         # self.projection = perspective( 45.0, width/float(height), 1.0, 1000.0 )
@@ -381,7 +381,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
         self.projection = perspective(45.0, self.canvas.size[0] /
                                       float(self.canvas.size[1]), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection'''
+        self.program['u_projection'] = self.projection
 
     def on_mouse_wheel(self, event):
         self.translate -= event.delta[1]
@@ -394,10 +394,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
     # Now the resize works well
     def on_resize(self, event):
-        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
-        self.projection = perspective(45.0, self.size[0] /
-                                      float(self.size[1]), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection
+        self.set_projection()
 
     def on_draw(self, event):
         # gloo.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 from glue.external.qt import QtGui
 from vispy import scene, app
-from vispy.color import get_colormap
+from vispy.color import get_colormap, Color
 
 __all__ = ['QtScatVispyWidget']
 
@@ -31,6 +31,9 @@ class QtScatVispyWidget(QtGui.QWidget):
 
         # create scatter object and fill in the data
         self.scatter = scene.visuals.Markers()
+
+        # Add a grid plane
+        self.grid = scene.visuals.GridLines(scale=(500, 500))
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
@@ -108,7 +111,16 @@ class QtScatVispyWidget(QtGui.QWidget):
             # size = np.ones((n, 1))
             # size[:, 0] = self.components[3]
             S[...] = self.components[3] ** (1. / 3) / 1.e1
-            self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
+
+
+            scatter_color =Color(self.options_widget.color, self.options_widget.opacity/100.0)
+
+            # Set default color = 'gold'
+            print('=============')
+            print('scatter_color is', scatter_color)
+            print('=============')
+
+            self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)
             self.view.add(self.scatter)
 
             # set clim value
@@ -144,7 +156,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         S = np.zeros(n)
         S[...] = _clim_components[3] ** (1. / 3) / 1.e1
         # Reset the data for scatter visual display
-        self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
+        self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=self.options_widget.color, size=S)
         self.canvas.update()
 
     def _update_clim(self):

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -64,7 +64,8 @@ class QtScatVispyWidget(QtGui.QWidget):
             components = [self.data[self.options_widget.ui.xAxisComboBox.currentText()],
                           self.data[self.options_widget.ui.yAxisComboBox.currentText()],
                           self.data[self.options_widget.ui.zAxisComboBox.currentText()],
-                          self.data[self.options_widget.ui.SizeComboBox.currentText()]]
+                          self.data[self.options_widget.ui.SizeComboBox.currentText()],
+                          self.data[self.options_widget.ui.ClimComboBox.currentText()]]
             return components
 
     def _refresh(self):
@@ -98,7 +99,17 @@ class QtScatVispyWidget(QtGui.QWidget):
             # size[:, 0] = self.components[3]
             S[...] = self.components[3] ** (1. / 3) / 1.e1
             self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
-
             self.view.add(self.scatter)
+
+            # set clim value
+            self._update_clim()
             self.canvas.update()
+
+    def _update_clim(self):
+        array = self.components[4]
+        print('===========')
+        print('array for component[4]', array)
+        print('===========')
+        self.options_widget.cmin = "%.4g" % np.nanmin(array)
+        self.options_widget.cmax = "%.4g" % np.nanmax(array)
 

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -274,8 +274,8 @@ class QtScatVispyWidget(QtGui.QWidget):
         print('=============')
         print('trans is', trans)
         print('=============')
-
-        self.scatter.transform = scene.STTransform(translate=trans)
+        stretch_scale = (3.0, 5.0, 1.0)
+        self.scatter.transform = scene.STTransform(translate=trans, scale=stretch_scale)
         max_dis = np.nanmax([(xmax-xmin)/2.0, (ymax-ymin)/2.0, (zmax-zmin)/2.0])
         print('scatter trnasform', trans)
         self.turn_cam.fov = 30.0

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -6,8 +6,7 @@ import numpy as np
 from glue.external.qt import QtGui
 from vispy import scene, app
 from vispy.color import get_colormap, Color
-# from vispy.visuals.transforms import (STTransform, MatrixTransform,\
-#                                       ChainTransform, TransformSystem)
+from vispy.visuals import transforms
 
 
 __all__ = ['QtScatVispyWidget']
@@ -36,23 +35,33 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.scatter = scene.visuals.Markers()
 
         # Add a grid plane
-        self.grid = scene.visuals.GridLines(parent=self.view)
-        # affine = scene.transforms.MatrixTransform()
-        # trans = self.view.transform
-        # self.grid.transform = STTransform(translate=(0, 1), scale=(0.5, 0.5))
+        # The pos of the visual will be at the center of the parent !
+        a = 400 - self.canvas.size[0]/2.0
+        b = 300 - self.canvas.size[1]/2.0
+        self.grid = scene.visuals.GridLines(scale=(0.5, 0.5), parent=self.view)
 
-        # trans = self.grid.transform
-
+        # Try to set the center of grid identical with the censer of the axis
+        # But found not so necessary now
+        # self.grid.transform = transforms.STTransform(translate=(a, b))
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
         print('==========')
-        print('axis tranform', self.axis.transform)
+        print('canvas size', self.canvas.size)
         self.widget_axis_scale = [1, 1, 1]
 
         # trans.scale = self.axis.transform.scale
 
         self._shown_data = None
+        self.canvas.events.resize.connect(self.on_resize)
+
+    def on_resize(self, event):
+        # TODO: resize of the grid?
+        print('==============')
+        print('canvas size', self.canvas.size)
+        a = 400 - self.canvas.size[0]/2.0
+        b = 300 - self.canvas.size[1]/2.0
+        # self.grid.transform = transforms.STTransform(translate=(a, b))
 
     @property
     def data(self):

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -19,7 +19,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
         super(QtScatVispyWidget, self).__init__(parent=parent)
 
-        vert = """
+        vert ="""
         #version 120
 
         // Uniforms
@@ -56,6 +56,7 @@ class QtScatVispyWidget(QtGui.QWidget):
             gl_PointSize = v_size + 2*(v_linewidth + 1.5*v_antialias);
         }
         """
+
 
         frag = """
         #version 120
@@ -225,14 +226,15 @@ class QtScatVispyWidget(QtGui.QWidget):
         # gloo.glBlendFunc(gloo.GL_SRC_ALPHA, gloo.GL_ONE) #_MINUS_SRC_ALPHA)
 
         # Prepare canvas
-        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
+        self.canvas = app.Canvas(keys='interactive', show=False)
         self.canvas.size = [600, 400]
         self.canvas.measure_fps()
 
         # Set up a viewbox to display the image with interactive pan/zoom
-        self.view = self.canvas.central_widget.add_view()
-        self.view.border_color = 'red'
-        self.view.parent = self.canvas.scene
+        # self.view = self.canvas.central_widget.add_view()
+        # self.view.border_color = 'red'
+        # self.view.parent = self.canvas.scene
+        self.view = np.eye(4,dtype=np.float32)
 
 
 
@@ -242,6 +244,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         gloo.set_state('translucent', clear_color='white')
 
         self.program = gloo.Program(vert, frag)
+        gloo.gl.use_gl('gl2 debug')
         # self.program = gloo.Program(self.VERT_SHADER, self.FRAG_SHADER)
         self.model = np.eye(4,dtype=np.float32)
         self.projection = np.eye(4,dtype=np.float32)
@@ -256,8 +259,8 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.zoom_timer = app.Timer(0.2, connect=self.on_timer, start=False)
 
         # Add a 3D axis to keep us oriented
-        self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
-        self.widget_axis_scale = [1, 1, 1]'''
+        # self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
+        # self.widget_axis_scale = [1, 1, 1]'''
 
         # self.program.bind(gloo.VertexBuffer(data))
 
@@ -329,7 +332,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
             # Dot size determination according to the mass - *2 for larger size
             S = np.zeros(n)
-            S[...] = 5* self.data.get_component('mass').data**(1./3)/1.e1
+            S[...] = 5* self.data.get_component('mass').data**(1./3)/1.e5
 
 
             # Wrap the data into a package
@@ -397,8 +400,8 @@ class QtScatVispyWidget(QtGui.QWidget):
 
     def on_draw(self, event):
         # gloo.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
-        gloo.clear()
         # gloo.clear()
+        gloo.clear()
         self.program.draw(mode='points')
 
     '''def apply_zoom(self):

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -29,7 +29,8 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.axes_names = None
         self._current_array = None
 
-        self.vol_visual = None
+        # create scatter object and fill in the data
+        self.scatter = scene.visuals.Markers()
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
@@ -96,11 +97,8 @@ class QtScatVispyWidget(QtGui.QWidget):
             # size = np.ones((n, 1))
             # size[:, 0] = self.components[3]
             S[...] = self.components[3] ** (1. / 3) / 1.e1
+            self.scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
 
-            # create scatter object and fill in the data
-            scatter = scene.visuals.Markers()
-            scatter.set_data(P, symbol='disc', edge_color=None, face_color=(1, 1, 1, .5), size=S)
-
-            self.view.add(scatter)
+            self.view.add(self.scatter)
             self.canvas.update()
 

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -21,7 +21,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         super(QtScatVispyWidget, self).__init__(parent=parent)
 
         # Prepare canvas
-        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False, always_on_top=False)
         self.canvas.measure_fps()
 
         # Set up a viewbox to display the image with interactive pan/zoom
@@ -213,6 +213,7 @@ class QtScatVispyWidget(QtGui.QWidget):
             if self.trans_flag == 0:
                 # Set transform for axis and camera
                 self.set_transform()
+            # self.scatter.transform = scene.STTransform(translate=(), scale=stretch_scale)
 
             # set clim value
             self._update_clim()
@@ -271,15 +272,19 @@ class QtScatVispyWidget(QtGui.QWidget):
         sizemin, sizemax = self.get_minmax(self.components[3])
         _axis_scale = (sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1)
         trans = (-(xmax+xmin)/2.0, -(ymax+ymin)/2.0, -(zmax+zmin)/2.0)
+        # trans = (0, 0, 0)
+        # trans = (-(zmax+zmin)/2.0, -(ymax+ymin)/2.0, -(xmax+xmin)/2.0)
         print('=============')
         print('trans is', trans)
         print('=============')
-        stretch_scale = (3.0, 5.0, 1.0)
-        self.scatter.transform = scene.STTransform(translate=trans, scale=stretch_scale)
+        # stretch_scale = (3.0, 5.0, 1.0)
+        # self.scatter.transform = scene.STTransform(translate=trans, scale=stretch_scale)
+        self.scatter.transform = scene.STTransform(translate=trans)
         max_dis = np.nanmax([(xmax-xmin)/2.0, (ymax-ymin)/2.0, (zmax-zmin)/2.0])
+
         print('scatter trnasform', trans)
         self.turn_cam.fov = 30.0
-        self.turn_cam.distance = tan(radians(60))*float(max_dis)
+        self.turn_cam.distance = tan(radians(90.0-self.turn_cam.fov/2.0))*float(max_dis)
         print('turn_cam distance', self.turn_cam.distance)
 
         self.axis.transform = scene.STTransform(scale=_axis_scale)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -239,8 +239,7 @@ class QtScatVispyWidget(QtGui.QWidget):
 
 
         # If you want to use gloo without vispy.app, use a gloo.context.FakeCanvas.
-        # fake_can = gloo.context.FakeCanvas()
-        # fake_can.flush()
+
         gloo.set_state('translucent', clear_color='white')
 
         self.program = gloo.Program(vert, frag)
@@ -268,9 +267,6 @@ class QtScatVispyWidget(QtGui.QWidget):
         # self.program['u_model'] = self.model
         # self.program['u_view'] = self.view
 
-
-
-
         self.timer_dt = 1.0/60
         self.timer_t = 0.0
         self.timer = app.Timer(self.timer_dt)
@@ -286,12 +282,10 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.rotate_theta_speed = 0.0
         self.rotate_phi_speed = 0.0
 
-
         # Connect events
         self.canvas.events.mouse_wheel.connect(self.on_mouse_wheel)
         self.canvas.events.draw.connect(self.on_draw)
-
-        # self.canvas.events.resize.connect(self.on_resize)
+        self.canvas.events.resize.connect(self.on_resize)
 
         # gl.glClearColor(0,0,0,1)
         # gl.glDisable(gl.GL_DEPTH_TEST)
@@ -379,7 +373,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         self.program['u_model'] = self.model
         self.update()
 
-    def set_projection(self):
+    '''def set_projection(self):
         # width, height = event.size
         # gloo.glViewport(0, 0, width, height)
         # self.projection = perspective( 45.0, width/float(height), 1.0, 1000.0 )
@@ -387,7 +381,7 @@ class QtScatVispyWidget(QtGui.QWidget):
         gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
         self.projection = perspective(45.0, self.canvas.size[0] /
                                       float(self.canvas.size[1]), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection
+        self.program['u_projection'] = self.projection'''
 
     def on_mouse_wheel(self, event):
         self.translate -= event.delta[1]
@@ -396,19 +390,22 @@ class QtScatVispyWidget(QtGui.QWidget):
 
         self.program['u_view'] = self.view
         self.program['u_size'] = 5 / self.translate
-        self.update()
+        self.canvas.update()
+
+    # Now the resize works well
+    def on_resize(self, event):
+        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
+        self.projection = perspective(45.0, self.size[0] /
+                                      float(self.size[1]), 1.0, 1000.0)
+        self.program['u_projection'] = self.projection
 
     def on_draw(self, event):
         # gloo.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
         # gloo.clear()
+        # RuntimeError: Program validation error
         gloo.clear()
         self.program.draw(mode='points')
 
-    '''def apply_zoom(self):
-        gloo.set_viewport(0, 0, self.canvas.physical_size[0], self.canvas.physical_size[1])
-        self.projection = perspective(45.0, self.size[0] /
-                                      float(self.size[1]), 1.0, 1000.0)
-        self.program['u_projection'] = self.projection'''
 
     # def on_paint(self, event):
     #     gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)

--- a/glue_vispy_viewers/scatter/scat_vispy_widget.py
+++ b/glue_vispy_viewers/scatter/scat_vispy_widget.py
@@ -36,40 +36,23 @@ class QtScatVispyWidget(QtGui.QWidget):
 
         # create scatter object and fill in the data
         self.scat_visual = None
-        self.scat_visual_data = None
+
+        """
+        Use scat_data and scat_data_refresh to make the scatter visual consistent with
+        stretch scale and threshold/clim
+        Because the realization of stretch scale and threshold/clim is through update & modify the visual data
+        """
+        self.scat_data = None
+        self.scat_data_refresh = None
 
         # Add a grid plane
-        # The pos of the visual will be at the center of the parent !
-        a = 400 - self.canvas.size[0]/2.0
-        b = 300 - self.canvas.size[1]/2.0
         self.grid = scene.visuals.GridLines(scale=(0.5, 0.5), parent=self.view)
-
-        # Try to set the center of grid identical with the censer of the axis
-        # But found not so necessary now
-        # self.grid.transform = transforms.STTransform(translate=(a, b))
 
         # Add a 3D axis to keep us oriented
         self.axis = scene.visuals.XYZAxis(parent=self.view.scene)
-        print('==========')
-        print('canvas size', self.canvas.size)
-        self.widget_axis_scale = [1, 1, 1]
 
         # Set a flag to make the transform just work once
         self.trans_flag = 0
-
-        # trans.scale = self.axis.transform.scale
-
-        self._shown_data = None
-        self.canvas.events.resize.connect(self.on_resize)
-
-
-
-    def on_resize(self, event):
-        # TODO: resize of the grid?
-
-        a = 400 - self.canvas.size[0]/2.0
-        b = 300 - self.canvas.size[1]/2.0
-        # self.grid.transform = transforms.STTransform(translate=(a, b))
 
     @property
     def data(self):
@@ -81,7 +64,6 @@ class QtScatVispyWidget(QtGui.QWidget):
             self._data = data
         else:
             self._data = data
-            first_data = data[data.components[0]]
             self.options_widget.set_valid_components([c.label for c in data.component_ids()])
             self._refresh()
 
@@ -96,19 +78,6 @@ class QtScatVispyWidget(QtGui.QWidget):
                           self.data[self.options_widget.ui.SizeComboBox.currentText()],
                           self.data[self.options_widget.ui.ClimComboBox.currentText()]]
             return components
-
-    # For better get the component for clim dataset
-    def clim_components(self, clim_filter):
-        if self.components is None:
-            return None
-        else:
-            clim_components = []
-            for each_com in self.components:
-                clim_components.append(each_com[clim_filter])
-            # S = self.scat_visual_data[2]
-            # clim_components.append(S[clim_filter])
-
-            return clim_components
 
     def set_subsets(self, subsets):
         self.subsets = subsets
@@ -140,49 +109,31 @@ class QtScatVispyWidget(QtGui.QWidget):
             scat_visual.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)
             self.scat_visual = scat_visual
             # Save this for refresh
-            self.scat_visual_data = [P, scatter_color, S]
+            self.scat_data = [P, scatter_color, S]
             self.view.add(self.scat_visual)
 
             if self.trans_flag == 0:
                 # Set transform for axis and camera
-                self.set_transform([self.components[0], self.components[0], self.components[0]], self.components[3])
-            # self.scatter.transform = scene.STTransform(translate=(), scale=stretch_scale)
+                self.set_transform([self.components[0], self.components[1], self.components[2]], self.components[3])
 
-            # set clim value
-            self._update_clim()
+            self.update_clim()
             self.canvas.update()
 
+    # TODO: I should put all update of visual data into this update_scatter_visual function
+    # and all updates of those UI options into _refresh and use it to call the update_scatter_visual to
+    # update current visual !
+
     def update_scatter_visual(self):
-        # It's similar to the add_scatter_visual but used for axis&size combobox update
-        if self.scat_visual is None:
-            return
-
-        n = len(self.components[3])
-        P = np.zeros((n, 3), dtype=np.float32)
-
-        X, Y, Z = P[:, 0], P[:, 1], P[:, 2]
-        X[...] = self.components[0]
-        Y[...] = self.components[1]
-        Z[...] = self.components[2]
-
-        S = np.zeros(n)
-        # Normalize the size based on median value of selected property to between 1-10
-        m = np.median(np.nan_to_num(self.components[3]))
-
-        if m < 1.0 or m > 10.0:
-            S[...] = self.components[3] * (1.0/m)
-        else:
-            S[...] = self.components[3]
-
-        scatter_color = Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
+        """
+        This method is called when basic properties for scatter visual got updated
+        including the selection of axis & size combobox
+        """
+        P = self.scat_data[0]
+        scatter_color = self.scat_data[1]
+        S = self.scat_data[2]
         self.scat_visual.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)
-        # Save this for refresh
-        self.scat_visual_data = [P, scatter_color, S]
-
         self.set_transform([self.components[0], self.components[1], self.components[2]], self.components[3])
-
-        # set clim value
-        self._update_clim()
+        self.update_clim()
         self.canvas.update()
 
     def _refresh(self):
@@ -192,31 +143,33 @@ class QtScatVispyWidget(QtGui.QWidget):
         if self.data is None:
             return
 
-        if self.scat_visual is not None and self.scat_visual_data is not None:
+        if self.scat_visual is not None and self.scat_data is not None:
             stretch_scale = self.options_widget.stretch
             # stretch_tran = [-0.5 * stretch_scale[idx] * len(self.components[2-idx]) for idx in range(3)]
-            P = self.scat_visual_data[0]
+            P = self.scat_data[0]
             n = P.shape[0]
             new_P = np.zeros((n, 3), dtype=np.float32)
             for idx in range(3):
                 new_P[:, idx] = P[:, idx] * stretch_scale[idx]
 
-            S = self.scat_visual_data[2]
+            S = self.scat_data[2]
             new_S = np.zeros(n)
             new_S = S[...] * stretch_scale[3]
 
             scatter_color = Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
+
             self.scat_visual.set_data(new_P, symbol='disc', edge_color=None,
                                       face_color=scatter_color, size=new_S)
 
             # Update the transform according to the stretch made here
             self.set_transform([new_P[:, 0], new_P[:, 1], new_P[:, 2]], new_S)
-            # self.scat_visual_data = [new_P, scatter_color, new_S]
+            self.scat_data_refresh = [new_P, scatter_color, new_S]
 
-    # Set the clim dataset and apply the new dataset to the current scatter visual
-    # TODO: add more clim options? Now the user could only clim one property
     def apply_clim(self):
-
+        """
+        This method can be called if the clim max & min textbox got updated
+        """
+        # TODO: put it together with _refresh
         currentid = self.options_widget.ui.ClimComboBox.currentText()
         _clim_pro = self.data[currentid]
 
@@ -228,43 +181,51 @@ class QtScatVispyWidget(QtGui.QWidget):
         more = _clim_pro > _cmin
         less = _clim_pro < _cmax
         clim_filter = np.all([more, less], axis=0)
-        _clim_components = self.clim_components(clim_filter)
+        _clim_scat_data = self.clim_for_scat_data(clim_filter)  # [position, color, size]
 
-        n = len(_clim_components[0])
+        n = len(_clim_scat_data[0])
         P = np.zeros((n, 3), dtype=np.float32)
 
         X, Y, Z = P[:, 0], P[:, 1], P[:, 2]
-        X[...] = _clim_components[0]
-        Y[...] = _clim_components[1]
-        Z[...] = _clim_components[2]
+        X[...] = _clim_scat_data[0]
+        Y[...] = _clim_scat_data[1]
+        Z[...] = _clim_scat_data[2]
 
         # Dot size determination according to the mass - *2 for larger size
         S = np.zeros(n)
-        m = np.median(np.nan_to_num(_clim_components[3]))
+        m = np.median(np.nan_to_num(_clim_scat_data[3]))
 
         if m < 1.0 or m > 10.0:
-            S[...] = _clim_components[3] * (1.0/m)
+            S[...] = _clim_scat_data[3] * (1.0/m)
         else:
-            S[...] = _clim_components[3]
+            S[...] = _clim_scat_data[3]
 
-        # S[...] = _clim_components[3] ** (1. / 3) / 1.e1
-        scatter_color =Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
+        scatter_color = Color(self.options_widget.true_color, self.options_widget.opacity/100.0)
 
         # Reset the data for scatter visual display
         self.scat_visual.set_data(P, symbol='disc', edge_color=None, face_color=scatter_color, size=S)
         self.canvas.update()
+        # self.scat_data = [P, scatter_color, S]
 
-    def _update_clim(self):
+    def update_clim(self):
         array = self.components[4]
 
         self.options_widget.cmin = "%.4g" % np.nanmin(array)
         self.options_widget.cmax = "%.4g" % np.nanmax(array)
 
+    def clim_for_scat_data(self, clim_filter):
+        clim_scat_data = []
+        for idx in range(3):
+            each_com = self.scat_data_refresh[0][:, idx]
+            clim_scat_data.append(each_com[clim_filter])
+        S = self.scat_data_refresh[2]
+        clim_scat_data.append(S[clim_filter])
+        return clim_scat_data
+
     def get_minmax(self, array):
         return float("%.4g" % np.nanmin(array)), float("%.4g" % np.nanmax(array))
 
-    # Set the transform of axis and distance of turntable camera according to the scale of the data
-    # After clicking the 'apply'
+    # Set the transform of visual&axis and distance of turntable camera according to the scale of the data
     def set_transform(self, position, size):
         # Get the min and max of each axis
         xmin, xmax = self.get_minmax(position[0])
@@ -273,8 +234,6 @@ class QtScatVispyWidget(QtGui.QWidget):
         sizemin, sizemax = self.get_minmax(size)
         _axis_scale = (sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1, sizemax ** (1. / 3) / 1.e1)
         trans = (-(xmax+xmin)/2.0, -(ymax+ymin)/2.0, -(zmax+zmin)/2.0)
-        # stretch_scale = (3.0, 5.0, 1.0)
-        # self.scat_visual.transform = scene.STTransform(translate=trans, scale=stretch_scale)
         self.scat_visual.transform = scene.STTransform(translate=trans)
         max_dis = np.nanmax([(xmax-xmin)/2.0, (ymax-ymin)/2.0, (zmax-zmin)/2.0])
 

--- a/glue_vispy_viewers/scatter/tests/test_scat_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scat_viewer.py
@@ -1,0 +1,13 @@
+from glue.qt import get_qapp
+from ..scat_vispy_viewer import ScatVispyViewer
+from glue.config import qt_client
+
+def test_viewer():
+
+    # Make sure QApplication is started
+    get_qapp()
+
+    # v = GlueVispyViewer()
+    # v = GlueVispyViewer()
+
+    qt_client.add(ScatVispyViewer)

--- a/glue_vispy_viewers/scatter/tests/test_scat_widget.py
+++ b/glue_vispy_viewers/scatter/tests/test_scat_widget.py
@@ -50,10 +50,12 @@ def test_widget():
     # op = VolumeOptionsWidget(vispy_widget=w)
     w.data = test_categorical_data()
     w.set_program()
-    w.set_projection()
+    # w.set_projection()
     # w.on_draw()
     w.canvas.show()
 
+    # Test apply_zoom
+    # w.apply_zoom()
 
     # Test timer
     # w.on_timer(TimerEvent(type='timer_timeout', iteration=3))
@@ -64,6 +66,6 @@ def test_widget():
     # w.on_key_press(KeyEvent(text='3'))
 
     # Test mouse_wheel
-    # w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, 0.5)))
-    # w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, -0.3)))
+    w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, 0.5)))
+    w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, -0.3)))
 

--- a/glue_vispy_viewers/scatter/tests/test_scat_widget.py
+++ b/glue_vispy_viewers/scatter/tests/test_scat_widget.py
@@ -1,0 +1,69 @@
+import numpy as np
+from ..scat_vispy_widget import QtScatVispyWidget
+from glue.qt import get_qapp
+# import pyfits
+import glue
+
+class KeyEvent(object):
+    def __init__(self, text):
+        self.text = text
+
+class MouseEvent(object):
+    def __init__(self, delta, type):
+        self.type = type
+        self.delta = delta
+
+class TimerEvent(object):
+    def __init__(self, type, iteration):
+        self.type = type
+        self.iteration = iteration
+
+def test_categorical_data():
+
+    data = glue.core.data.Data(label="Test Cat Data 1")
+
+    comp_x1 = glue.core.data.Component(np.array([4, 5, 6]))
+    comp_y1 = glue.core.data.Component(np.array([1, 2, 3]))
+    comp_z1 = glue.core.data.Component(np.array([2, 3, 4]))
+    comp_mass = glue.core.data.Component(np.array([0.55, 1, 1.5]))
+
+    data.add_component(comp_x1, 'x_gal')
+    data.add_component(comp_y1, 'y_gal')
+    data.add_component(comp_z1, 'z_gal')
+    data.add_component(comp_mass, 'mass')
+
+    return data
+
+def test_widget():
+
+    # Make sure QApplication is started
+    get_qapp()
+
+    # Create fake data
+    # data = Data(primary=np.arange(1000).reshape((10,10,10)))
+
+    # fits_file_name = '/Users/penny/Works/cloud_catalog_july14_2015.fits'
+    # fitsfile = pyfits.open(fits_file_name)
+
+    # Set up widget
+    w = QtScatVispyWidget()
+    # op = VolumeOptionsWidget(vispy_widget=w)
+    w.data = test_categorical_data()
+    w.set_program()
+    w.set_projection()
+    # w.on_draw()
+    w.canvas.show()
+
+
+    # Test timer
+    # w.on_timer(TimerEvent(type='timer_timeout', iteration=3))
+
+    # Test key presses
+    # w.on_key_press(KeyEvent(text=' '))
+    # w.on_key_press(KeyEvent(text=''))
+    # w.on_key_press(KeyEvent(text='3'))
+
+    # Test mouse_wheel
+    # w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, 0.5)))
+    # w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, -0.3)))
+

--- a/glue_vispy_viewers/scatter/tests/test_scat_widget.py
+++ b/glue_vispy_viewers/scatter/tests/test_scat_widget.py
@@ -49,7 +49,7 @@ def test_widget():
     w = QtScatVispyWidget()
     # op = VolumeOptionsWidget(vispy_widget=w)
     w.data = test_categorical_data()
-    w.set_program()
+    w._refresh()
     # w.set_projection()
     # w.on_draw()
     w.canvas.show()

--- a/glue_vispy_viewers/scatter/tests/test_scat_widget.py
+++ b/glue_vispy_viewers/scatter/tests/test_scat_widget.py
@@ -69,3 +69,5 @@ def test_widget():
     w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, 0.5)))
     w.on_mouse_wheel(MouseEvent(type='mouse_wheel', delta=(0, -0.3)))
 
+    # Test mouse_press, move, release
+    # w.on_mouse_press(MouseEvent(type='mouse_press', pos=(5, 5)))

--- a/glue_vispy_viewers/volume/vol_vispy_widget.py
+++ b/glue_vispy_viewers/volume/vol_vispy_widget.py
@@ -16,7 +16,7 @@ class QtVispyWidget(QtGui.QWidget):
         super(QtVispyWidget, self).__init__(parent=parent)
 
         # Prepare canvas
-        self.canvas = scene.SceneCanvas(keys='interactive', show=False)
+        self.canvas = scene.SceneCanvas(keys='interactive', show=False, always_on_top=False)
         self.canvas.measure_fps()
 
         # Set up a viewbox to display the image with interactive pan/zoom

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name='glue-vispy-viewers',
       author_email='glueviz@gmail.com',
       packages = find_packages(),
       package_data={'glue_vispy_viewers.volume': ['*.ui'],
-                    'glue_vispy_viewers.isosurface': ['*.ui']},
+                    'glue_vispy_viewers.isosurface': ['*.ui'],
+                    'glue_vispy_viewers.scatter': ['*.ui']},
       entry_points=entry_points
     )

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup, find_packages
 entry_points = """
 [glue.plugins]
 vispy_volume=glue_vispy_viewers.volume:setup
+vispy_scatter=glue_vispy_viewers.scatter:setup
 """
 
 # Add the following to the above entry points to enable the isosurface viewer


### PR DESCRIPTION
Here is the Glue 3D scatter plot viewer with a very simple user interface(see below), which enables the property selection by the user now.
![image](https://cloud.githubusercontent.com/assets/13411839/11462443/6dd426fa-96e2-11e5-96f0-9ce1209d3dff.png)

The questions I got now are:
- How to combine the `size` property selected by the user from the dataset with the real size showed in the viewer. In the current code we use the method from @maxwelltsai while it only works for the `mass` property.
- Any other functionalities to be implemented like color scheme or axis? 
- Here is a pretty example from the Vispy for the galaxy simulation display, maybe we could borrow some shader code from it? https://github.com/vispy/vispy/blob/master/examples/demo/gloo/galaxy/galaxy.py

Do you have any advice? Thanks and please feel free to polish the code :)
