### PR TITLE
Added buttons to flip limits

### DIFF
--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 from glue.external.qt import QtGui
 
-from glue.utils.qt.widget_properties import CurrentComboProperty, FloatLineProperty, connect_bool_button
+from glue.utils.qt.widget_properties import CurrentComboProperty, FloatLineProperty, connect_bool_button, ButtonProperty
 from glue.utils.qt import load_ui
 
 __all__ = ["VispyOptionsWidget"]
@@ -75,6 +75,10 @@ class VispyOptionsWidget(QtGui.QWidget):
         self.ui.value_y_max.editingFinished.connect(self._update_limits)
         self.ui.value_z_max.editingFinished.connect(self._update_limits)
 
+        self.ui.button_flip_x.clicked.connect(self._flip_x)
+        self.ui.button_flip_y.clicked.connect(self._flip_y)
+        self.ui.button_flip_z.clicked.connect(self._flip_z)
+
         self.ui.reset_button.clicked.connect(self._vispy_widget._reset_view)
 
         self._components = {}
@@ -98,6 +102,24 @@ class VispyOptionsWidget(QtGui.QWidget):
         self._set_limits_enabled(True)
 
         self.ui.value_x_min.editingFinished.emit()
+
+    def _flip_x(self):
+        self._set_limits_enabled(False)
+        self.x_min, self.x_max = self.x_max, self.x_min
+        self._set_limits_enabled(True)
+        self.ui.value_x_min.editingFinished.emit()
+
+    def _flip_y(self):
+        self._set_limits_enabled(False)
+        self.y_min, self.y_max = self.y_max, self.y_min
+        self._set_limits_enabled(True)
+        self.ui.value_y_min.editingFinished.emit()
+
+    def _flip_z(self):
+        self._set_limits_enabled(False)
+        self.z_min, self.z_max = self.z_max, self.z_min
+        self._set_limits_enabled(True)
+        self.ui.value_z_min.editingFinished.emit()
 
     def _set_attributes_enabled(self, value):
 

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -20,15 +20,22 @@
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="15" column="0" colspan="4">
-    <widget class="QPushButton" name="reset_button">
-     <property name="text">
-      <string>Reset View</string>
+   <item row="2" column="6">
+    <widget class="QLineEdit" name="value_x_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="3">
+   <item row="0" column="3" colspan="4">
     <widget class="QComboBox" name="combo_x_attribute"/>
+   </item>
+   <item row="4" column="0" colspan="7">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
@@ -37,24 +44,21 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="value_x_min"/>
-   </item>
-   <item row="2" column="3">
-    <widget class="QLineEdit" name="value_x_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>stretch:</string>
+      <string>min</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="17" column="0" colspan="7">
+    <widget class="QPushButton" name="reset_button">
+     <property name="text">
+      <string>Reset View</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -67,61 +71,65 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="0" colspan="4">
+   <item row="10" column="4">
+    <widget class="QToolButton" name="button_flip_z">
+     <property name="text">
+      <string>&lt;&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0" colspan="7">
     <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>x axis</string>
-     </property>
-    </widget>
+   <item row="10" column="3">
+    <widget class="QLineEdit" name="value_z_min"/>
    </item>
    <item row="1" column="3">
-    <widget class="QLineEdit" name="value_x_max"/>
+    <widget class="QLineEdit" name="value_x_min"/>
    </item>
-   <item row="12" column="0" colspan="4">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_3">
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>max:</string>
+      <string>stretch:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="7" column="6">
     <widget class="QLineEdit" name="value_y_stretch">
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="10" column="3">
-    <widget class="QLineEdit" name="value_z_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <widget class="QLineEdit" name="value_z_min"/>
+   <item row="6" column="4">
+    <widget class="QToolButton" name="button_flip_y">
+     <property name="text">
+      <string>&lt;&gt;</string>
+     </property>
+    </widget>
    </item>
-   <item row="10" column="1" colspan="2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="6">
+    <widget class="QLineEdit" name="value_z_max"/>
+   </item>
+   <item row="11" column="3" colspan="3">
     <widget class="QSlider" name="slider_z_stretch">
      <property name="minimum">
       <number>-10000</number>
@@ -137,65 +145,71 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="3">
-    <widget class="QLineEdit" name="value_z_max"/>
-   </item>
-   <item row="8" column="1" colspan="3">
-    <widget class="QComboBox" name="combo_z_attribute"/>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
+   <item row="11" column="6">
+    <widget class="QLineEdit" name="value_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>min</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
+   <item row="9" column="3" colspan="4">
+    <widget class="QComboBox" name="combo_z_attribute"/>
    </item>
-   <item row="9" column="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="3">
+   <item row="6" column="6">
     <widget class="QLineEdit" name="value_y_max"/>
    </item>
-   <item row="5" column="2">
+   <item row="6" column="5">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>max:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="4">
-    <widget class="Line" name="line">
+   <item row="1" column="5">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="5">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="6">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="7">
+    <widget class="Line" name="line_3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
+   <item row="7" column="3" colspan="3">
     <widget class="QSlider" name="slider_y_stretch">
      <property name="minimum">
       <number>-10000</number>
@@ -211,36 +225,20 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="3">
+   <item row="5" column="3" colspan="4">
     <widget class="QComboBox" name="combo_y_attribute"/>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSlider" name="slider_x_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="4">
+   <item row="8" column="0" colspan="7">
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="3">
     <widget class="QLineEdit" name="value_y_min"/>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -253,13 +251,40 @@
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
-    <widget class="QCheckBox" name="checkbox_axes">
+   <item row="1" column="4">
+    <widget class="QToolButton" name="button_flip_x">
      <property name="text">
-      <string>Coordinate axes</string>
+      <string>&lt;&gt;</string>
      </property>
-     <property name="checked">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="12" column="3" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="checkbox_axes">
+       <property name="text">
+        <string>Coordinate axes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="3" colspan="3">
+    <widget class="QSlider" name="slider_x_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>399</width>
+    <width>436</width>
     <height>367</height>
    </rect>
   </property>
@@ -20,45 +20,14 @@
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="2" column="6">
-    <widget class="QLineEdit" name="value_x_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3" colspan="4">
-    <widget class="QComboBox" name="combo_x_attribute"/>
-   </item>
-   <item row="4" column="0" colspan="7">
+   <item row="4" column="2" colspan="5">
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="0" colspan="7">
-    <widget class="QPushButton" name="reset_button">
-     <property name="text">
-      <string>Reset View</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
+   <item row="5" column="2">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -67,69 +36,73 @@
       </font>
      </property>
      <property name="text">
-      <string>z axis</string>
+      <string>y axis</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="4">
-    <widget class="QToolButton" name="button_flip_z">
-     <property name="text">
-      <string>&lt;&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="0" colspan="7">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="3">
-    <widget class="QLineEdit" name="value_z_min"/>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="value_x_min"/>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="6">
-    <widget class="QLineEdit" name="value_y_stretch">
+   <item row="2" column="5">
+    <widget class="QLineEdit" name="value_x_stretch">
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
+   <item row="7" column="2">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>stretch:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="4">
-    <widget class="QToolButton" name="button_flip_y">
-     <property name="text">
-      <string>&lt;&gt;</string>
+   <item row="2" column="3" colspan="2">
+    <widget class="QSlider" name="slider_x_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="11" column="2">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>stretch:</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="6">
-    <widget class="QLineEdit" name="value_z_max"/>
+   <item row="14" column="2" colspan="5">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
-   <item row="11" column="3" colspan="3">
+   <item row="9" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_z_attribute"/>
+   </item>
+   <item row="1" column="4">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3" colspan="2">
     <widget class="QSlider" name="slider_z_stretch">
      <property name="minimum">
       <number>-10000</number>
@@ -145,51 +118,23 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="6">
-    <widget class="QLineEdit" name="value_z_stretch">
+   <item row="7" column="5">
+    <widget class="QLineEdit" name="value_y_stretch">
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min</string>
-     </property>
-    </widget>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="value_x_min"/>
    </item>
-   <item row="9" column="3" colspan="4">
-    <widget class="QComboBox" name="combo_z_attribute"/>
+   <item row="5" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_y_attribute"/>
    </item>
-   <item row="6" column="6">
-    <widget class="QLineEdit" name="value_y_max"/>
+   <item row="0" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_x_attribute"/>
    </item>
-   <item row="6" column="5">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="5">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="6">
-    <widget class="QLineEdit" name="value_x_max"/>
-   </item>
-   <item row="0" column="0">
+   <item row="0" column="2">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -202,14 +147,43 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="0" colspan="7">
-    <widget class="Line" name="line_3">
+   <item row="2" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="3">
+    <widget class="QLineEdit" name="value_z_min"/>
+   </item>
+   <item row="1" column="5">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="10" column="5">
+    <widget class="QLineEdit" name="value_z_max"/>
+   </item>
+   <item row="8" column="2" colspan="5">
+    <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="7" column="3" colspan="3">
+   <item row="6" column="3">
+    <widget class="QLineEdit" name="value_y_min"/>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="5">
+    <widget class="QLineEdit" name="value_y_max"/>
+   </item>
+   <item row="7" column="3" colspan="2">
     <widget class="QSlider" name="slider_y_stretch">
      <property name="minimum">
       <number>-10000</number>
@@ -225,20 +199,28 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="3" colspan="4">
-    <widget class="QComboBox" name="combo_y_attribute"/>
+   <item row="6" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
    </item>
-   <item row="8" column="0" colspan="7">
-    <widget class="Line" name="line">
+   <item row="16" column="2" colspan="5">
+    <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
-    <widget class="QLineEdit" name="value_y_min"/>
+   <item row="10" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
    </item>
-   <item row="5" column="0">
+   <item row="9" column="2">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -247,18 +229,25 @@
       </font>
      </property>
      <property name="text">
-      <string>y axis</string>
+      <string>z axis</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
-    <widget class="QToolButton" name="button_flip_x">
+   <item row="11" column="5">
+    <widget class="QLineEdit" name="value_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="2" colspan="4">
+    <widget class="QPushButton" name="reset_button">
      <property name="text">
-      <string>&lt;&gt;</string>
+      <string>Reset View</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="3" colspan="4">
+   <item row="15" column="3" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QCheckBox" name="checkbox_axes">
@@ -272,19 +261,33 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="3" colspan="3">
-    <widget class="QSlider" name="slider_x_stretch">
-     <property name="minimum">
-      <number>-10000</number>
+   <item row="10" column="4">
+    <widget class="QToolButton" name="button_flip_z">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
      </property>
-     <property name="maximum">
-      <number>10000</number>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
      </property>
-     <property name="singleStep">
-      <number>0</number>
+     <property name="text">
+      <string>⇄</string>
      </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QToolButton" name="button_flip_y">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
      </property>
     </widget>
    </item>

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -94,6 +94,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.radio_size_fixed.toggled.connect(self._update_size_mode)
         self.ui.radio_size_linear.toggled.connect(self._update_size_mode)
         self.ui.combo_size_attribute.currentIndexChanged.connect(self._update_size_limits)
+        self.ui.button_flip_size.clicked.connect(self._flip_size)
 
     def _update_size_mode(self):
         if self.ui.radio_size_fixed.isChecked():
@@ -111,6 +112,9 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         else:
             self.size_vmin, self.size_vmax = self.default_limits(self.size_attribute)
             self._size_limits[self.size_attribute] = self.size_vmin, self.size_vmax
+
+    def _flip_size(self):
+        self.size_vmin, self.size_vmax = self.size_vmax, self.size_vmin
 
     def _setup_color_options(self):
 
@@ -135,6 +139,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.radio_color_fixed.toggled.connect(self._update_color_mode)
         self.ui.radio_color_linear.toggled.connect(self._update_color_mode)
         self.ui.combo_cmap_attribute.currentIndexChanged.connect(self._update_cmap_limits)
+        self.ui.button_flip_cmap.clicked.connect(self._flip_cmap)
 
     def _update_color_mode(self):
         if self.ui.radio_color_fixed.isChecked():
@@ -152,6 +157,9 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         else:
             self.cmap_vmin, self.cmap_vmax = self.default_limits(self.cmap_attribute)
             self._cmap_limits[self.cmap_attribute] = self.cmap_vmin, self.cmap_vmax
+
+    def _flip_cmap(self):
+        self.cmap_vmin, self.cmap_vmax = self.cmap_vmax, self.cmap_vmin
 
     def default_limits(self, attribute):
         # For subsets, we want to compute the limits based on the full

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -6,42 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
-    <height>345</height>
+    <width>486</width>
+    <height>349</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="value_size_vmax"/>
-   </item>
    <item row="7" column="0">
     <widget class="QRadioButton" name="radio_color_linear">
      <property name="text">
       <string>Linear</string>
      </property>
     </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Alpha:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="value_fixed_size"/>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QComboBox" name="combo_size_attribute"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_2">
@@ -56,13 +34,17 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
-    <widget class="QLineEdit" name="value_cmap_vmax"/>
-   </item>
    <item row="2" column="0">
     <widget class="QRadioButton" name="radio_size_linear">
      <property name="text">
       <string>Linear</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="radio_size_fixed">
+     <property name="text">
+      <string>Fixed</string>
      </property>
     </widget>
    </item>
@@ -79,32 +61,8 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QRadioButton" name="radio_color_fixed">
-     <property name="text">
-      <string>Fixed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QRadioButton" name="radio_size_fixed">
-     <property name="text">
-      <string>Fixed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QSlider" name="slider_size_scaling">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>50</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
+   <item row="8" column="1">
+    <widget class="QLineEdit" name="value_cmap_vmin"/>
    </item>
    <item row="6" column="1">
     <widget class="QColorBox" name="label_color">
@@ -119,25 +77,81 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="value_fixed_size"/>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Alpha:</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1">
     <widget class="QLineEdit" name="value_size_vmin"/>
    </item>
-   <item row="8" column="1">
-    <widget class="QLineEdit" name="value_cmap_vmin"/>
+   <item row="6" column="0">
+    <widget class="QRadioButton" name="radio_color_fixed">
+     <property name="text">
+      <string>Fixed</string>
+     </property>
+    </widget>
    </item>
-   <item row="13" column="1" colspan="2">
-    <widget class="QColormapCombo" name="combo_cmap"/>
+   <item row="3" column="2">
+    <widget class="QToolButton" name="button_flip_size">
+     <property name="text">
+      <string>&lt;&gt;</string>
+     </property>
+    </widget>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="3" column="3">
+    <widget class="QLineEdit" name="value_size_vmax"/>
+   </item>
+   <item row="2" column="1" colspan="3">
+    <widget class="QComboBox" name="combo_size_attribute"/>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QSlider" name="slider_size_scaling">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>50</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
     <widget class="QComboBox" name="combo_cmap_attribute"/>
    </item>
-   <item row="14" column="1" colspan="2">
+   <item row="8" column="3">
+    <widget class="QLineEdit" name="value_cmap_vmax"/>
+   </item>
+   <item row="13" column="1" colspan="3">
+    <widget class="QColormapCombo" name="combo_cmap"/>
+   </item>
+   <item row="14" column="1" colspan="3">
     <widget class="QSlider" name="slider_alpha">
      <property name="maximum">
       <number>100</number>
      </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2">
+    <widget class="QToolButton" name="button_flip_cmap">
+     <property name="text">
+      <string>&lt;&gt;</string>
      </property>
     </widget>
    </item>

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -104,11 +104,19 @@
     </widget>
    </item>
    <item row="3" column="2">
-    <widget class="QToolButton" name="button_flip_size">
-     <property name="text">
-      <string>&lt;&gt;</string>
-     </property>
-    </widget>
+       <widget class="QToolButton" name="button_flip_size">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">padding: 0px</string>
+        </property>
+        <property name="text">
+         <string>⇄</string>
+        </property>
+       </widget>
    </item>
    <item row="3" column="3">
     <widget class="QLineEdit" name="value_size_vmax"/>
@@ -149,11 +157,19 @@
     </widget>
    </item>
    <item row="8" column="2">
-    <widget class="QToolButton" name="button_flip_cmap">
-     <property name="text">
-      <string>&lt;&gt;</string>
-     </property>
-    </widget>
+       <widget class="QToolButton" name="button_flip_cmap">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">padding: 0px</string>
+        </property>
+        <property name="text">
+         <string>⇄</string>
+        </property>
+       </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Currently this looks like this:

<img width="316" alt="screen shot 2016-02-25 at 9 07 02 am" src="https://cloud.githubusercontent.com/assets/314716/13314924/ae023954-db9f-11e5-9a95-76b9bc077710.png">

@borkin @PennyQ - I was trying to find a clear but unobtrusive way to do this. Do you think this is intuitive?

Fixes #70
