### PR TITLE
Improve volume rendering shader

### DIFF
--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -5,7 +5,7 @@ def get_translucent_cmap(r, g, b):
     class TranslucentCmap(BaseColormap):
         glsl_map = """
         vec4 translucent_fire(float t) {{
-            return vec4(t * {0}, t * {1}, t * {2}, t * 0.5);
+            return vec4({0}, {1}, {2}, t);
         }}
         """.format(r, g, b)
         


### PR DESCRIPTION
This is now based on the maximum intensity profile method to avoid having the rendering depend on the depth of the data. This also blends the color using the average (weighted by alpha) and then uses the maximum alpha as the final alpha to prevent pixels from getting _darker_ when adding layers (which is counter-intuitive).

<img width="1016" alt="screen shot 2016-02-26 at 11 03 48 am" src="https://cloud.githubusercontent.com/assets/314716/13350614/173e2480-dc79-11e5-9dba-24446bae25dc.png">
