### PR TITLE
Add the 3d scatter selection toolbar 

### DIFF
--- a/glue_vispy_viewers/common/toolbar.py
+++ b/glue_vispy_viewers/common/toolbar.py
@@ -1,6 +1,8 @@
 import os
 
 import numpy as np
+from vispy import app, scene
+from matplotlib import path
 
 from glue.external.qt import QtCore, QtGui
 from glue.core.edit_subset_mode import EditSubsetMode
@@ -10,6 +12,10 @@ from glue.utils import nonpartial
 from glue.core import Data
 
 POINT_ICON = os.path.join(os.path.dirname(__file__), 'glue_point.png')
+
+"""
+This class is for showing the toolbar UI and drawing selection line on canvas
+"""
 
 
 class VispyDataViewerToolbar(QtGui.QToolBar):
@@ -26,8 +32,16 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         # Set visual preferences
         self.setIconSize(QtCore.QSize(25, 25))
 
-        # Set up selection actions
+        # Initialize drawing visual
+        self.line_pos = []
+        self.line = scene.visuals.Line(color='white', method='gl', parent=self._vispy_widget.canvas.scene)
 
+        # Selection defaults
+        self._scatter = None
+        self.selection_origin = (0, 0)
+        self.selected = []
+
+        # Set up selection actions
         a = QtGui.QAction(get_icon('glue_lasso'), 'Lasso Selection', parent)
         a.triggered.connect(nonpartial(self.toggle_lasso))
         a.setCheckable(True)
@@ -41,6 +55,13 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         parent.addAction(a)
         self.addAction(a)
         self.rectangle_action = a
+
+        a = QtGui.QAction(get_icon('glue_circle'), 'Ellipse Selection', parent)
+        a.triggered.connect(nonpartial(self.toggle_ellipse))
+        a.setCheckable(True)
+        parent.addAction(a)
+        self.addAction(a)
+        self.ellipse_action = a
 
         # TODO: change path to icon once it's in a released version of glue
         a = QtGui.QAction(QtGui.QIcon(POINT_ICON), 'Point Selection', parent)
@@ -60,6 +81,7 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
             self.mode = 'lasso'
             self.rectangle_action.setChecked(False)
             self.point_action.setChecked(False)
+            self.ellipse_action.setChecked(False)
         else:
             self.mode = None
 
@@ -68,6 +90,16 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
             self.mode = 'rectangle'
             self.lasso_action.setChecked(False)
             self.point_action.setChecked(False)
+            self.ellipse_action.setChecked(False)
+        else:
+            self.mode = None
+
+    def toggle_ellipse(self):
+        if self.ellipse_action.isChecked():
+            self.mode = 'ellipse'
+            self.lasso_action.setChecked(False)
+            self.point_action.setChecked(False)
+            self.rectangle_action.setChecked(False)
         else:
             self.mode = None
 
@@ -76,6 +108,7 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
             self.mode = 'point'
             self.lasso_action.setChecked(False)
             self.rectangle_action.setChecked(False)
+            self.ellipse_action.setChecked(False)
         else:
             self.mode = None
 
@@ -89,6 +122,8 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         if value is None:
             self.enable_camera_events()
         else:
+            # when the selection icon is clicked, the view should be updated and the tr should also be updated
+            self._vispy_widget.canvas.update()
             self.disable_camera_events()
 
     @property
@@ -108,48 +143,120 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         self.camera._viewbox.events.mouse_wheel.disconnect(self.camera.viewbox_mouse_event)
 
     def on_mouse_press(self, event):
-        # TODO: here we need to start a new selection shape based on the mode
-        pass
+        self.selection_origin = event.pos
 
     def on_mouse_move(self, event):
         # TODO: here we need to update the selection shape based on the mode
-        pass
+        """
+        Draw selection line along dragging mouse
+        """
+        if event.button == 1 and event.is_dragging and self.mode is not None:
+            if self.mode is 'lasso':
+                self.line_pos.append(event.pos)
+                self.line.set_data(np.array(self.line_pos))
+            else:
+                width = event.pos[0] - self.selection_origin[0]
+                height = event.pos[1] - self.selection_origin[1]
+                center = (width / 2. + self.selection_origin[0], height / 2. + self.selection_origin[1], 0)
+
+                if self.mode is 'rectangle':
+                    self.line_pos = self.rectangle_vertice(center, height, width)
+                    self.line.set_data(np.array(self.line_pos))
+                # TODO: add draw ellipse here
+                if self.mode is 'ellipse':
+                    self.line_pos = self.ellipse_vertice(center, radius=(np.abs(width / 2.), np.abs(height / 2.)),
+                                                         start_angle=0., span_angle=360., num_segments=500)
+                    self.line.set_data(pos=np.array(self.line_pos), connect='strip')
+            self._vispy_widget.canvas.update()
 
     def on_mouse_release(self, event):
-
-        # TODO: here we need to finalize the selection shape based on the mode
-
-        # Get the component IDs
-        x_att = self._vispy_widget.options.x_att
-        y_att = self._vispy_widget.options.y_att
-        z_att = self._vispy_widget.options.z_att
-
-        # Get the visible datasets
-        visible_data = self.get_visible_data()
-
-        # TODO: here we need to get a mask for the selection, which we assume
-        # will be called ``mask``. For now, we set the mask to a random mask.
-        mask = np.random.random(visible_data[0].shape) > 0.5
-
-        # We now make a subset state. For scatter plots we'll want to use an
-        # ElementSubsetState, while for cubes, we'll need to change to a
-        # MaskSubsetState.
-        subset_state = ElementSubsetState(np.where(mask)[0])
-
-        # We now check what the selection mode is, and update the selection as
-        # needed (this is delegated to the correct subset mode).
-        mode = EditSubsetMode()
-        focus = visible_data[0] if len(visible_data) > 0 else None
-        mode.update(self._data_collection, subset_state, focus_data=focus)
+        pass
 
     def get_visible_data(self):
         """
         Returns all the visible data objects in the viewer
         """
-        visible = []
-        # Loop over visible layer artists
-        for layer_artist in self._vispy_data_viewer._layer_artist_container:
-            # Only extract Data objects, not subsets
-            if isinstance(layer_artist.layer, Data):
-                visible.append(layer_artist.layer)
-        return visible
+        pass
+
+    '''this function should be abstract'''
+
+    def mark_selected(self):
+        pass
+
+    def rectangle_vertice(self, center, height, width):
+        """
+        Borrow from _generate_vertices in vispy/visuals/rectangle.py
+        """
+        half_height = height / 2.
+        half_width = width / 2.
+
+        bias1 = np.ones(4) * half_width
+        bias2 = np.ones(4) * half_height
+
+        corner1 = np.empty([1, 3], dtype=np.float32)
+        corner2 = np.empty([1, 3], dtype=np.float32)
+        corner3 = np.empty([1, 3], dtype=np.float32)
+        corner4 = np.empty([1, 3], dtype=np.float32)
+
+        corner1[:, 0] = center[0] - bias1[0]
+        corner1[:, 1] = center[1] - bias2[0]
+        corner1[:, 2] = 0
+
+        corner2[:, 0] = center[0] + bias1[1]
+        corner2[:, 1] = center[1] - bias2[1]
+        corner2[:, 2] = 0
+
+        corner3[:, 0] = center[0] + bias1[2]
+        corner3[:, 1] = center[1] + bias2[2]
+        corner3[:, 2] = 0
+
+        corner4[:, 0] = center[0] - bias1[3]
+        corner4[:, 1] = center[1] + bias2[3]
+        corner4[:, 2] = 0
+
+        # Get vertices between each corner of the rectangle for border drawing
+        vertices = np.concatenate(([[center[0], center[1], 0.]],
+                                   [[center[0] - half_width, center[1], 0.]],
+                                   corner1,
+                                   [[center[0], center[1] - half_height, 0.]],
+                                   corner2,
+                                   [[center[0] + half_width, center[1], 0.]],
+                                   corner3,
+                                   [[center[0], center[1] + half_height, 0.]],
+                                   corner4,
+                                   [[center[0] - half_width, center[1], 0.]]))
+
+        # vertices = np.array(output, dtype=np.float32)
+        return vertices[1:, ..., :2]
+
+    def ellipse_vertice(self, center, radius, start_angle, span_angle, num_segments):
+        # Borrow from _generate_vertices in vispy/visual/ellipse.py
+
+        if isinstance(radius, (list, tuple)):
+            if len(radius) == 2:
+                xr, yr = radius
+            else:
+                raise ValueError("radius must be float or 2 value tuple/list"
+                                 " (got %s of length %d)" % (type(radius),
+                                                             len(radius)))
+        else:
+            xr = yr = radius
+
+        start_angle = np.deg2rad(start_angle)
+
+        vertices = np.empty([num_segments + 2, 2], dtype=np.float32) # Segment as 1000
+
+        # split the total angle into num_segments intances
+        theta = np.linspace(start_angle,
+                            start_angle + np.deg2rad(span_angle),
+                            num_segments + 1)
+
+        # PolarProjection
+        vertices[:-1, 0] = center[0] + xr * np.cos(theta)
+        vertices[:-1, 1] = center[1] + yr * np.sin(theta)
+
+        # close the curve
+        vertices[num_segments + 1] = np.float32([center[0], center[1]])
+
+        return vertices[:-1]
+

--- a/glue_vispy_viewers/common/toolbar.py
+++ b/glue_vispy_viewers/common/toolbar.py
@@ -140,14 +140,13 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         self.camera._viewbox.events.mouse_wheel.disconnect(self.camera.viewbox_mouse_event)
 
     def on_mouse_press(self, event):
-        self.selection_origin = event.pos
+        pass
 
     def on_mouse_move(self, event):
-        # TODO: here we need to update the selection shape based on the mode
         """
         Draw selection line along dragging mouse
         """
-        if event.button == 1 and event.is_dragging and self.mode is not None:
+        if event.button == 1 and event.is_dragging and self.mode is not 'point':
             if self.mode is 'lasso':
                 self.line_pos.append(event.pos)
                 self.line.set_data(np.array(self.line_pos))
@@ -159,7 +158,7 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
                 if self.mode is 'rectangle':
                     self.line_pos = self.rectangle_vertice(center, height, width)
                     self.line.set_data(np.array(self.line_pos))
-                # TODO: add draw ellipse here
+
                 if self.mode is 'ellipse':
                     self.line_pos = self.ellipse_vertice(center, radius=(np.abs(width / 2.), np.abs(height / 2.)),
                                                          start_angle=0., span_angle=360., num_segments=500)
@@ -170,9 +169,6 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         pass
 
     def get_visible_data(self):
-        """
-        Returns all the visible data objects in the viewer
-        """
         pass
 
     def rectangle_vertice(self, center, height, width):

--- a/glue_vispy_viewers/common/toolbar.py
+++ b/glue_vispy_viewers/common/toolbar.py
@@ -5,11 +5,8 @@ from vispy import app, scene
 from matplotlib import path
 
 from glue.external.qt import QtCore, QtGui
-from glue.core.edit_subset_mode import EditSubsetMode
-from glue.core.subset import ElementSubsetState
 from glue.icons.qt import get_icon
 from glue.utils import nonpartial
-from glue.core import Data
 
 POINT_ICON = os.path.join(os.path.dirname(__file__), 'glue_point.png')
 
@@ -176,11 +173,6 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
         """
         Returns all the visible data objects in the viewer
         """
-        pass
-
-    '''this function should be abstract'''
-
-    def mark_selected(self):
         pass
 
     def rectangle_vertice(self, center, height, width):

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -23,9 +23,9 @@ class BaseVispyViewer(DataViewer):
 
         # TODO: uncomment the following lines once the selection is
         # correctly implemented.
-        # toolbar = VispyDataViewerToolbar(vispy_widget=self._vispy_widget,
-        #                                  parent=self)
-        # self.addToolBar(toolbar)
+        toolbar = VispyDataViewerToolbar(vispy_widget=self._vispy_widget,
+                                         parent=self)
+        self.addToolBar(toolbar)
 
     def register_to_hub(self, hub):
 

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -21,10 +21,7 @@ class BaseVispyViewer(DataViewer):
 
         self._options_widget = VispyOptionsWidget(vispy_widget=self._vispy_widget, data_viewer=self)
 
-        # TODO: uncomment the following lines once the selection is
-        # correctly implemented.
-        toolbar = VispyDataViewerToolbar(vispy_widget=self._vispy_widget,
-                                         parent=self)
+        toolbar = self._toolbar_cls(vispy_widget=self._vispy_widget, parent=self)
         self.addToolBar(toolbar)
 
     def register_to_hub(self, hub):

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -48,8 +48,10 @@ class VispyWidget(QtGui.QWidget):
         # Create a turntable camera. For now, this is the only camerate type
         # we support, but if we support more in future, we should implement
         # that here
-        self.view.camera = scene.cameras.TurntableCamera(parent=self.view.scene,
-                                                         fov=60, distance=2)
+
+        # Remove the fov=60 here to solve the mismatch of selection problem
+        # self.view.camera = scene.cameras.TurntableCamera(parent=self.view.scene, distance=2)
+        self.view.camera = scene.cameras.TurntableCamera(parent=self.view.scene, distance=2.0)
 
         # Add the native canvas widget to this widget
         layout = QtGui.QVBoxLayout()

--- a/glue_vispy_viewers/isosurface/isosurface_toolbar.py
+++ b/glue_vispy_viewers/isosurface/isosurface_toolbar.py
@@ -1,0 +1,26 @@
+__author__ = 'penny'
+
+"""
+This is for getting the selection part and highlight it
+"""
+from ..common.toolbar import VispyDataViewerToolbar
+
+
+class IsosurfaceSelectionToolbar(VispyDataViewerToolbar):
+
+    def __init__(self, vispy_widget=None, parent=None):
+        super(IsosurfaceSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
+        self.vol_data = None
+
+    # TODO: get current visual and volume data
+    def get_visible_data(self):
+        pass
+
+    def on_mouse_press(self, event):
+        pass
+
+    def on_mouse_move(self, event):
+        pass
+
+    def on_mouse_release(self, event):
+        pass

--- a/glue_vispy_viewers/isosurface/isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/isosurface_viewer.py
@@ -1,6 +1,7 @@
 from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import IsosurfaceLayerArtist
 from .layer_style_widget import IsosurfaceLayerStyleWidget
+from .isosurface_toolbar import IsosurfaceSelectionToolbar
 
 
 class VispyIsosurfaceViewer(BaseVispyViewer):
@@ -8,6 +9,7 @@ class VispyIsosurfaceViewer(BaseVispyViewer):
     LABEL = "3D Isosurface Rendering"
 
     _layer_style_widget_cls = IsosurfaceLayerStyleWidget
+    _toolbar_cls = IsosurfaceSelectionToolbar
 
     def add_data(self, data):
 

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -84,6 +84,10 @@ class ScatterLayerArtist(LayerArtistBase):
         self._size_data = None
 
     @property
+    def visual(self):
+        return self._multiscat
+
+    @property
     def visible(self):
         return self._visible
 

--- a/glue_vispy_viewers/scatter/scatter_toolbar.py
+++ b/glue_vispy_viewers/scatter/scatter_toolbar.py
@@ -1,0 +1,133 @@
+__author__ = 'penny'
+
+"""
+This is for getting the selection part and highlight it
+"""
+from ..common.toolbar import VispyDataViewerToolbar
+from .layer_artist import ScatterLayerArtist
+
+import numpy as np
+from matplotlib import path
+
+from glue.core import Data
+
+class ScatterSelectionToolbar(VispyDataViewerToolbar):
+
+    def __init__(self, vispy_widget=None, parent=None):
+        super(ScatterSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
+
+        self.scatter_data = None
+        self.facecolor = np.ones((1064,4), dtype=np.float)
+        self.white = (1.0, 1.0, 1.0, 1.0)
+        self.black = (0.0, 0.0, 0.0, 0.0)
+
+    @property
+    def layer(self):
+        return self._layer
+
+    @layer.setter
+    def layer(self, value):
+        if value is not None:
+            self._layer = value[0]
+        else:
+            self._layer = None
+
+    def get_visible_data(self):
+        visible = []
+        # Loop over visible layer artists
+        for layer_artist in self._vispy_data_viewer._layer_artist_container:
+            # Only extract Data objects, not subsets
+            if isinstance(layer_artist.layer, Data):
+                visible.append(layer_artist.layer)
+        visual = layer_artist.visual  # we only have one visual for each canvas
+        return visible, visual
+
+    def mark_selected(self):
+        self.facecolor[self.facecolor[:, 1] != 1.0] = self.white
+        self._scatter.set_data(self.scatter_data, face_color=self.facecolor)
+        for i in self.selected:
+            self.facecolor[i] = [1.0, 0.0, 0.0, 1]
+
+        self._scatter.set_data(self.scatter_data, face_color=self.facecolor)
+        self._scatter.update()
+
+    # TODO: implement advanced point selection here
+    def on_mouse_press(self, event):
+        self.selection_origin = event.pos
+        if self.mode is 'point':
+            # Ray intersection on the CPU to highlight the selected point(s)
+
+            data = self.tr.map(self.data)[:, :2]
+            print('data', data)
+            m1 = data > (event.pos - 4)
+            m2 = data < (event.pos + 4)
+
+            self.selected = np.argwhere(m1[:,0] & m1[:,1] & m2[:,0] & m2[:,1])
+            self.mark_selected()
+
+    def on_mouse_release(self, event):
+
+        # TODO: here we need to finalize the selection shape based on the mode
+
+        # Get the component IDs
+        x_att = self._vispy_widget.options.x_att
+        y_att = self._vispy_widget.options.y_att
+        z_att = self._vispy_widget.options.z_att
+
+        # Get the visible datasets
+        visible_data, visual = self.get_visible_data()
+
+        layer = visible_data[0]
+        layer_data = np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose()
+
+        # TODO: test multiple data for this
+        if len(visible_data) > 1:
+            n = len(visible_data)
+            for id in range(1, n):
+                layer = visible_data[id]
+                np.append(layer_data, np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose(), axis=0)
+
+        tr = visual.node_transform(self._vispy_widget.view)
+
+        self._scatter = visual
+        self.scatter_data = layer_data
+
+        if event.button == 1 and self.mode is not None and self.mode is not 'point':
+            # self.facecolor[self.facecolor[:, 1] != 1.0] = self.white
+            data = tr.map(layer_data)[:, :2]
+
+            selection_path = path.Path(self.line_pos, closed=True)
+
+            mask = [selection_path.contains_points(data)]
+
+            self.selected = mask
+            self.mark_selected()
+
+            # TODO: this part doesn't work well
+            # the mask is correct when the view is not changed
+            # but with this subset code it still can't be correctly displayed on the screen
+            # maybe should add view.update somewhere
+
+            # We now make a subset state. For scatter plots we'll want to use an
+            # ElementSubsetState, while for cubes, we'll need to change to a
+            # MaskSubsetState.
+            # subset_state = ElementSubsetState(np.where(mask)[0])
+
+            # We now check what the selection mode is, and update the selection as
+            # needed (this is delegated to the correct subset mode).
+            # mode = EditSubsetMode()
+            # focus = visible_data[0] if len(visible_data) > 0 else None
+            # mode.update(self._data_collection, subset_state, focus_data=focus)
+
+            # print('selection done', focus)
+            # Reset lasso
+
+            self.line_pos = []  # TODO: Empty pos input is not allowed for line_visual
+            self.line.set_data(np.array(self.line_pos))
+            self.line.update()
+
+            self.selection_origin = (0, 0)
+
+            self._vispy_widget.canvas.update()
+
+

--- a/glue_vispy_viewers/scatter/scatter_toolbar.py
+++ b/glue_vispy_viewers/scatter/scatter_toolbar.py
@@ -17,7 +17,6 @@ class ScatterSelectionToolbar(VispyDataViewerToolbar):
 
     def __init__(self, vispy_widget=None, parent=None):
         super(ScatterSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
-        self.scatter_data = None
 
     def get_visible_data(self):
         visible = []
@@ -31,61 +30,37 @@ class ScatterSelectionToolbar(VispyDataViewerToolbar):
 
     # TODO: implement advanced point selection here
     def on_mouse_press(self, event):
-        self.selection_origin = event.pos
         if self.mode is 'point':
             # Ray intersection on the CPU to highlight the selected point(s)
+            data = self.get_map_data()
 
-            data = self.tr.map(self.data)[:, :2]
-            print('data', data)
-            m1 = data > (event.pos - 4)
-            m2 = data < (event.pos + 4)
+            # TODO: the threshold 2 here could replaced with a slider bar to control the selection region in the future
+            m1 = data > (event.pos - 2)
+            m2 = data < (event.pos + 2)
 
-            self.selected = np.argwhere(m1[:,0] & m1[:,1] & m2[:,0] & m2[:,1])
-            self.mark_selected()
+            array_mark = np.argwhere(m1[:,0] & m1[:,1] & m2[:,0] & m2[:,1])
+            mask = np.zeros(len(data), dtype=bool)
+            for i in array_mark:
+                index = int(i[0])
+                mask[index] = True
+            visible_data, visual = self.get_visible_data()
+
+            self.mark_selected(mask, visible_data)
+            self._vispy_widget.canvas.update()
+
+        else:
+            self.selection_origin = event.pos
 
     def on_mouse_release(self, event):
-
-        # TODO: here we need to finalize the selection shape based on the mode
-
-        # Get the component IDs
-        x_att = self._vispy_widget.options.x_att
-        y_att = self._vispy_widget.options.y_att
-        z_att = self._vispy_widget.options.z_att
 
         # Get the visible datasets
         visible_data, visual = self.get_visible_data()
 
-        layer = visible_data[0]
-        layer_data = np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose()
-
-        # TODO: multiple data here not work well
-        # A possible solution for multiple data would be combine them into a whole data set, like the np.append here
-        if len(visible_data) > 1:
-            n = len(visible_data)
-            for id in range(1, n):
-                layer = visible_data[id]
-                np.append(layer_data, np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose(), axis=0)
-
-        tr = visual.node_transform(self._vispy_widget.view)
-
-        self._scatter = visual
-        self.scatter_data = layer_data
-
         if event.button == 1 and self.mode is not None and self.mode is not 'point':
-            data = tr.map(layer_data)[:, :2]
+            data = self.get_map_data()
             selection_path = path.Path(self.line_pos, closed=True)
             mask = selection_path.contains_points(data)
-
-            # We now make a subset state. For scatter plots we'll want to use an
-            # ElementSubsetState, while for cubes, we'll need to change to a
-            # MaskSubsetState.
-            subset_state = ElementSubsetState(np.where(mask)[0])
-
-            # We now check what the selection mode is, and update the selection as
-            # needed (this is delegated to the correct subset mode).
-            mode = EditSubsetMode()
-            focus = visible_data[0] if len(visible_data) > 0 else None
-            mode.update(self._data_collection, subset_state, focus_data=focus)
+            self.mark_selected(mask, visible_data)
 
             # Reset lasso
             self.line_pos = []  # TODO: Empty pos input is not allowed for line_visual
@@ -96,4 +71,37 @@ class ScatterSelectionToolbar(VispyDataViewerToolbar):
 
             self._vispy_widget.canvas.update()
 
+    def mark_selected(self, mask, visible_data):
+        # We now make a subset state. For scatter plots we'll want to use an
+        # ElementSubsetState, while for cubes, we'll need to change to a
+        # MaskSubsetState.
+        subset_state = ElementSubsetState(np.where(mask)[0])
 
+        # We now check what the selection mode is, and update the selection as
+        # needed (this is delegated to the correct subset mode).
+        mode = EditSubsetMode()
+        focus = visible_data[0] if len(visible_data) > 0 else None
+        mode.update(self._data_collection, subset_state, focus_data=focus)
+
+    def get_map_data(self):
+        # Get the component IDs
+        x_att = self._vispy_widget.options.x_att
+        y_att = self._vispy_widget.options.y_att
+        z_att = self._vispy_widget.options.z_att
+
+        # Get the visible datasets
+        visible_data, visual = self.get_visible_data()
+        layer = visible_data[0]
+        layer_data = np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose()
+
+        # TODO: multiple data here not work well now
+        # A possible solution for multiple data would be combine them into a whole data set, like the np.append here
+        # if len(visible_data) > 1:
+        #     n = len(visible_data)
+        #     for id in range(1, n):
+        #         layer = visible_data[id]
+        #         np.append(layer_data, np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose(), axis=0)
+
+        tr = visual.node_transform(self._vispy_widget.view)
+        data = tr.map(layer_data)[:, :2]
+        return data

--- a/glue_vispy_viewers/scatter/scatter_toolbar.py
+++ b/glue_vispy_viewers/scatter/scatter_toolbar.py
@@ -12,26 +12,12 @@ from matplotlib import path
 
 from glue.core import Data
 
+
 class ScatterSelectionToolbar(VispyDataViewerToolbar):
 
     def __init__(self, vispy_widget=None, parent=None):
         super(ScatterSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
-
         self.scatter_data = None
-        self.facecolor = np.ones((1064,4), dtype=np.float)
-        self.white = (1.0, 1.0, 1.0, 1.0)
-        self.black = (0.0, 0.0, 0.0, 0.0)
-
-    @property
-    def layer(self):
-        return self._layer
-
-    @layer.setter
-    def layer(self, value):
-        if value is not None:
-            self._layer = value[0]
-        else:
-            self._layer = None
 
     def get_visible_data(self):
         visible = []
@@ -72,7 +58,8 @@ class ScatterSelectionToolbar(VispyDataViewerToolbar):
         layer = visible_data[0]
         layer_data = np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose()
 
-        # TODO: test multiple data for this
+        # TODO: multiple data here not work well
+        # A possible solution for multiple data would be combine them into a whole data set, like the np.append here
         if len(visible_data) > 1:
             n = len(visible_data)
             for id in range(1, n):

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -1,7 +1,7 @@
 from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import ScatterLayerArtist
 from .layer_style_widget import ScatterLayerStyleWidget
-
+from .scatter_toolbar import ScatterSelectionToolbar
 
 class VispyScatterViewer(BaseVispyViewer):
 
@@ -25,6 +25,10 @@ class VispyScatterViewer(BaseVispyViewer):
 
         if first_layer_artist:
             self._options_widget.set_limits(*layer_artist.default_limits)
+
+        # TODO: add toolbar here
+        scatter_toolbar = ScatterSelectionToolbar(vispy_widget=self._vispy_widget, parent=self)
+        self.addToolBar(scatter_toolbar)
 
         return True
 

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -8,6 +8,7 @@ class VispyScatterViewer(BaseVispyViewer):
     LABEL = "3D Scatter Plot"
 
     _layer_style_widget_cls = ScatterLayerStyleWidget
+    _toolbar_cls = ScatterSelectionToolbar
 
     def add_data(self, data):
 
@@ -25,10 +26,6 @@ class VispyScatterViewer(BaseVispyViewer):
 
         if first_layer_artist:
             self._options_widget.set_limits(*layer_artist.default_limits)
-
-        # TODO: add toolbar here
-        scatter_toolbar = ScatterSelectionToolbar(vispy_widget=self._vispy_widget, parent=self)
-        self.addToolBar(scatter_toolbar)
 
         return True
 

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -78,6 +78,9 @@ class VolumeLayerArtist(LayerArtistBase):
         if isinstance(self.layer, Subset):
             add_callback(self, 'subset_mode', nonpartial(self._update_data))
 
+    @property
+    def visual(self):
+        return self._multivol
 
     @property
     def bbox(self):

--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -1,0 +1,33 @@
+__author__ = 'penny'
+
+"""
+This is for getting the selection part and highlight it
+"""
+from ..common.toolbar import VispyDataViewerToolbar
+import numpy as np
+from matplotlib import path
+
+from glue.core import Data
+
+
+class VolumeSelectionToolbar(VispyDataViewerToolbar):
+
+    def __init__(self, vispy_widget=None, parent=None):
+        super(VolumeSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
+        self.vol_data = None
+
+    # TODO: get current visual and volume data
+    def get_visible_data(self):
+        pass
+
+    def on_mouse_press(self, event):
+        self.selection_origin = event.pos
+        if self.mode is 'point':
+            # TODO: add dendrogram selection here
+            pass
+
+    def on_mouse_move(self, event):
+        pass
+
+    def on_mouse_release(self, event):
+        pass

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -1,6 +1,7 @@
 from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import VolumeLayerArtist
 from .layer_style_widget import VolumeLayerStyleWidget
+from .volume_toolbar import VolumeSelectionToolbar
 
 
 class VispyVolumeViewer(BaseVispyViewer):
@@ -8,6 +9,7 @@ class VispyVolumeViewer(BaseVispyViewer):
     LABEL = "3D Volume Rendering"
 
     _layer_style_widget_cls = VolumeLayerStyleWidget
+    _toolbar_cls = VolumeSelectionToolbar
 
     def add_data(self, data):
 


### PR DESCRIPTION
I divided the scatter (and later volume) toolbar from the Base Toolbar, which enables us to implement some advanced selections based on different data sets in the future. 

Two problems to be solved within this PR:
1. Subset doesn't work well, only one point will be highlighted during the selection.
2. Two toolbars are shown in the same window (as see below), I guess it's because I use `super().__init__` in the ScatterSelectionToolbar so the `__init__()` of Base Toolbar is called twice.

![image](https://cloud.githubusercontent.com/assets/13411839/13866828/a7cf5f16-ec8f-11e5-8ad3-1c659e694a1f.png)
