### PR TITLE
add 3d axis with ticks

### DIFF
--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -72,7 +72,7 @@ class VispyWidget(QtGui.QWidget):
                          font_size=10, axis_color=fc, tick_color=fc, text_color=fc,
                          parent=self.view.scene)
 
-        self.zax = scene.visuals.Axis(pos=[[-1.0, -1.0], [-1.0, 1.0]], tick_direction=(-1, 0),
+        self.zax = scene.visuals.Axis(pos=[[-1.0, -1.0], [-1.0, 1.0]], tick_direction=(1, 0),
                          font_size=10, axis_color=fc, tick_color=fc, text_color=fc,
                          parent=self.view.scene)
 

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -114,20 +114,6 @@ class VispyWidget(QtGui.QWidget):
         add_callback(self, 'visible_axes', nonpartial(self._toggle_axes))
         add_callback(self, 'perspective_view', nonpartial(self._toggle_perspective))
 
-    # TODO: how to get data here?
-    def update_axis_label(self, data):
-        # data object
-        label = []
-        tick_value = []
-        if data.coords:
-            # TODO: think about 4th dim
-            for i in range(data.ndim):
-                label.append(data.coords.axis_label(i))  # ['Vopt', 'Declination', 'Right Ascension']
-                tick_value.append(data._world_component_ids[label[i]])
-            self.xax.domain = tick_value[0]
-            self.yax.domain = tick_value[1]
-            self.zax.domain = tick_value[2]
-
     def _toggle_axes(self):
         if self.visible_axes:
             self.axis.parent = self.view.scene
@@ -182,6 +168,10 @@ class VispyWidget(QtGui.QWidget):
         for visual in self.limit_transforms:
             self.limit_transforms[visual].scale = scale
             self.limit_transforms[visual].translate = translate
+
+        self.xax.domain = (self.options.x_min, self.options.x_max)
+        self.yax.domain = (self.options.y_min, self.options.y_max)
+        self.zax.domain = (self.options.z_min, self.options.z_max)
 
     def _reset_view(self):
         self.view.camera.reset()

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -56,6 +56,38 @@ class VispyWidget(QtGui.QWidget):
         self.axis.transform = self.scene_transform
         self.view.add(self.axis)
 
+        # add the axis visual from Vispy library, with 2D ticks and labels, more refer to:
+        # https://github.com/vispy/vispy/blob/959fe5643ec9d717f9f01ba97552ec1c1668ec04/vispy/visuals/axis.py
+        # TODO: move this 3d axis into a subclass, set domain as data shape, add coordinate labels
+        self.xax = scene.visuals.Axis(pos=[[-1.0, -1.0], [1.0, -1.0]], domain=(5., 10.), tick_direction=(0, -1),
+                         font_size=10, axis_color='w', tick_color='w', text_color='w',
+                         parent=self.view.scene)
+
+        self.yax = scene.visuals.Axis(pos=[[-1.0, -1.0], [-1.0, 1.0]], tick_direction=(-1, 0),
+                         font_size=10, axis_color='w', tick_color='w', text_color='w',
+                         parent=self.view.scene)
+
+        self.zax = scene.visuals.Axis(pos=[[-1.0, -1.0], [-1.0, 1.0]], tick_direction=(-1, 0),
+                         font_size=10, axis_color='w', tick_color='w', text_color='w',
+                         parent=self.view.scene)
+
+        self.xytr = STTransform()
+        self.xytr.translate = [0., 0., -1.]
+
+        self.xax.transform = self.xytr
+        self.yax.transform = self.xytr
+
+        # zax is the 180 rotation of yax
+        self.ztr = STTransform()
+        try:
+            self.ztr = self.ztr.as_matrix()
+        except AttributeError:   # Vispy <= 0.4
+            self.ztr = self.ztr.as_affine()
+
+        self.ztr.rotate(180, (0, 1, 1))
+        self.ztr.translate((-2., -1., 0.))
+        self.zax.transform = self.ztr
+
         # Create a turntable camera. For now, this is the only camerate type
         # we support, but if we support more in future, we should implement
         # that here
@@ -97,6 +129,16 @@ class VispyWidget(QtGui.QWidget):
 
     def _update_stretch(self, *stretch):
         self.scene_transform.scale = stretch
+
+        # set stretch for 3d axis here
+        self.xytr.scale = stretch
+        self.xytr.translate = [0., 0., -stretch[2]]
+
+        # self.ztr.scale will accumulate with previous settings, so we need reset
+        self.ztr.reset()
+        self.ztr.rotate(180, (0, 1, 1))
+        self.ztr.translate((-2., -1., 0.))
+        self.ztr.scale(stretch)
         self._update_limits()
 
     def _update_limits(self):


### PR DESCRIPTION
Add the ticks of 3D axis as shown below, it works well with the `stretch` operation.

What to do next:
1. Move it into a subclass inherited from `AxisVisual` in vispy.
2. Set the `domain` parameter the same as cube/scatter data shape.
3. Add a axis instruction label.

![image](https://cloud.githubusercontent.com/assets/13411839/14124817/a33ea192-f5d5-11e5-9ddf-55a8a0f39742.png)
