### PR TITLE
Fix _update data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Workaround OpenGL issue that caused cubes with size > 2048 along any
   dimension to not display.
 
+- Fix issue with _update_data on base VisPy viewer.
+
 0.2 (2015-03-11)
 ----------------
 

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -73,10 +73,10 @@ class BaseVispyViewer(DataViewer):
             self._layer_artist_container.pop(message.subset)
             self._vispy_widget.canvas.update()
 
-    def _update_data(self):
-        self._vispy_widget.data = self.data
-        self._vispy_widget.add_volume_visual()
-        self._redraw()
+    def _update_data(self, message):
+        if message.data in self._layer_artist_container:
+            for layer_artist in self._layer_artist_container[message.data]:
+                layer_artist._update_data()
 
     def _redraw(self):
         self._vispy_widget.canvas.render()


### PR DESCRIPTION
This should fix this kind of error:

``` python
ERROR: TypeError: _update_data() takes exactly 1 argument (2 given) [glue.core.hub]
Traceback (most recent call last):
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/utils/misc.py", line 57, in result
return func(*args, **kwargs)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/app/qt/layer_tree_widget.py", line 199, in _do_action
LinkEditor.update_links(self.data_collection)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/dialogs/link_editor/qt/link_editor.py", line 128, in update_links
collection.set_links(links)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/core/data_collection.py", line 151, in set_links
self._link_manager.update_data_components(d)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/core/link_manager.py", line 192, in update_data_components
self._merge_duplicate_ids(data)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/core/link_manager.py", line 166, in _merge_duplicate_ids
data.update_id(d, o)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/core/data.py", line 572, in update_id
self.hub.broadcast(msg)
File "/Users/agoodman/anaconda/lib/python2.7/site-packages/glue/core/hub.py", line 181, in broadcast
handler(message)
TypeError: _update_data() takes exactly 1 argument (2 given)
```
