### PR TITLE
Set volume rendering default alpha to 1 for max opacity

### DIFF
--- a/glue_vispy_viewers/volume/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/layer_style_widget.py
@@ -43,7 +43,7 @@ class VolumeLayerStyleWidget(QtGui.QWidget):
 
         # Set initial values
         self.layer_artist.color = self.layer.style.color
-        self.layer_artist.alpha = self.layer.style.alpha
+        self.layer_artist.alpha = self.layer.style.alpha = 1.0
         with delay_callback(self.layer_artist, 'attribute'):
             self.attribute = self.visible_components[0]
             self._update_limits()


### PR DESCRIPTION
Attempted fix for glue-viz/glue#922 by setting default alpha (opacity) to 1 (max).
