### PR TITLE
Set parent to None not [] when clearing layer artist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Make sure an error is raised if data is not 3-dimensional and shape doesn’t
   agree with existing data in volume viewer.
 
+- Fix a bug that caused exceptions when clearing/removing layer artists. [#117]
+
 - Workaround OpenGL issue that caused cubes with size > 2048 along any
   dimension to not display.
 

--- a/glue_vispy_viewers/isosurface/layer_artist.py
+++ b/glue_vispy_viewers/isosurface/layer_artist.py
@@ -65,7 +65,7 @@ class IsosurfaceLayerArtist(LayerArtistBase):
         """
         Remove the layer artist from the visualization
         """
-        self._iso_visual.parent = []
+        self._iso_visual.parent = None
 
     def update(self):
         """

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -111,7 +111,7 @@ class ScatterLayerArtist(LayerArtistBase):
         """
         Remove the layer artist from the visualization
         """
-        self._multiscat.parent = []
+        self._multiscat.parent = None
 
     def update(self):
         """


### PR DESCRIPTION
This prevents errors about deleted C/C++ objects.
