### PR TITLE
Rotate view for 3d viewers

### DIFF
--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -47,6 +47,9 @@ class VispyOptionsWidget(QtGui.QWidget):
                                self.ui.value_y_stretch,
                                self.ui.value_z_stretch]
 
+        self.rotate_slider = self.ui.slider_rotate
+        self.rotate_slider.valueChanged.connect(self._update_rotate)
+
         self._event_lock = False
 
         for slider, label in zip(self.stretch_sliders, self.stretch_values):
@@ -57,6 +60,7 @@ class VispyOptionsWidget(QtGui.QWidget):
             slider.valueChanged.connect(self._update_stretch)
 
         connect_bool_button(self._vispy_widget, 'visible_axes', self.ui.checkbox_axes)
+        connect_bool_button(self._vispy_widget, 'rotate_view', self.ui.checkbox_rotate)
 
         if self._data_viewer is not None:
             self.ui.combo_x_attribute.currentIndexChanged.connect(self._data_viewer._update_attributes)
@@ -216,6 +220,10 @@ class VispyOptionsWidget(QtGui.QWidget):
         self._vispy_widget._update_stretch(self.x_stretch,
                                            self.y_stretch,
                                            self.z_stretch)
+
+    def _update_rotate(self):
+        rotate_value = 10** (self.rotate_slider.value() / 1e4)
+        self._vispy_widget._update_rotate(rotate_value)
 
     def _update_labels_from_sliders(self, label, slider):
         if self._event_lock:

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -14,253 +14,21 @@
    <string>3D_Volume</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <property name="margin">
-    <number>5</number>
-   </property>
-   <item row="4" column="2" colspan="5">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>y axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="5">
-    <widget class="QLineEdit" name="value_x_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3" colspan="2">
-    <widget class="QSlider" name="slider_x_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="2" colspan="5">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_z_attribute"/>
-   </item>
-   <item row="1" column="4">
-    <widget class="QToolButton" name="button_flip_x">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="3" colspan="2">
-    <widget class="QSlider" name="slider_z_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="5">
-    <widget class="QLineEdit" name="value_y_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="value_x_min"/>
-   </item>
-   <item row="5" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_y_attribute"/>
-   </item>
-   <item row="0" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_x_attribute"/>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>x axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="3">
-    <widget class="QLineEdit" name="value_z_min"/>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLineEdit" name="value_x_max"/>
-   </item>
-   <item row="10" column="5">
-    <widget class="QLineEdit" name="value_z_max"/>
-   </item>
-   <item row="8" column="2" colspan="5">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3">
-    <widget class="QLineEdit" name="value_y_min"/>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="5">
-    <widget class="QLineEdit" name="value_y_max"/>
-   </item>
-   <item row="7" column="3" colspan="2">
-    <widget class="QSlider" name="slider_y_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="2" colspan="5">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>z axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="5">
-    <widget class="QLineEdit" name="value_z_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="2" colspan="4">
-    <widget class="QPushButton" name="reset_button">
-     <property name="text">
-      <string>Reset View</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="3" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="checkbox_axes">
-       <property name="text">
-        <string>Coordinate axes</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="10" column="4">
     <widget class="QToolButton" name="button_flip_z">
      <property name="font">
@@ -290,6 +58,273 @@
       <string>⇄</string>
      </property>
     </widget>
+   </item>
+   <item row="10" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="2" colspan="5">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="5">
+    <widget class="QLineEdit" name="value_y_max"/>
+   </item>
+   <item row="7" column="3" colspan="2">
+    <widget class="QSlider" name="slider_y_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="QLineEdit" name="value_y_min"/>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="5">
+    <widget class="QLineEdit" name="value_z_max"/>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="5">
+    <widget class="QLineEdit" name="value_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_z_attribute"/>
+   </item>
+   <item row="14" column="2" colspan="5">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2" colspan="5">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3" colspan="2">
+    <widget class="QSlider" name="slider_z_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="5">
+    <widget class="QLineEdit" name="value_y_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="5">
+    <widget class="QLineEdit" name="value_x_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="value_x_min"/>
+   </item>
+   <item row="5" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_y_attribute"/>
+   </item>
+   <item row="0" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_x_attribute"/>
+   </item>
+   <item row="9" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>z axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2" colspan="5">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="3">
+    <widget class="QLineEdit" name="value_z_min"/>
+   </item>
+   <item row="17" column="2" colspan="4">
+    <widget class="QPushButton" name="reset_button">
+     <property name="text">
+      <string>Reset View</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>y axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3" colspan="2">
+    <widget class="QSlider" name="slider_x_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="2" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="checkbox_rotate">
+       <property name="text">
+        <string>Rotate view</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="slider_rotate">
+       <property name="minimum">
+        <number>-10000</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="singleStep">
+        <number>0</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_axes">
+       <property name="text">
+        <string>Coordinate axes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>254</width>
-    <height>279</height>
+    <width>381</width>
+    <height>345</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -242,38 +242,12 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="2" colspan="4">
+   <item row="11" column="2" colspan="4">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="reset_button">
        <property name="text">
         <string>Reset View</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkbox_rotate">
-       <property name="text">
-        <string>Rotate view</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="slider_rotate">
-       <property name="minimum">
-        <number>-10000</number>
-       </property>
-       <property name="maximum">
-        <number>10000</number>
-       </property>
-       <property name="singleStep">
-        <number>0</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -288,6 +262,32 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="10" column="2">
+    <widget class="QCheckBox" name="checkbox_rotate">
+     <property name="text">
+      <string>Rotate view</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="3" colspan="2">
+    <widget class="QSlider" name="slider_rotate">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -127,8 +127,7 @@ class VispyWidget(QtGui.QWidget):
         self.view.camera.reset()
 
     def rotate(self, event):
-        self.rotate_speed += self.rotate_slider_val
-        self.view.camera.azimuth = self.rotate_speed
+        self.view.camera.azimuth += self.rotate_slider_val
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
I use a `check box` to start the `Timer` that controls the rotation, and a `slider bar` to set the rotation speed. But there are some conflicts between other setting controls like stretch and min/max limit. Should we disable some when we start the rotation or let them work simultaneously? @astrofrog 

![image](https://cloud.githubusercontent.com/assets/13411839/14582546/4fb9e13a-03d6-11e6-9ede-0adab3c8c839.png)
