### PR TITLE
Optimize layout of options for 3D viewers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 
 - Fix issue with _update_data on base VisPy viewer.
 
+- Optimize the layout of options for the layer style editors to save space.
+
 0.2 (2015-03-11)
 ----------------
 

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>327</width>
+    <width>254</width>
     <height>279</height>
    </rect>
   </property>
@@ -45,27 +45,6 @@
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
-   </item>
-   <item row="10" column="3" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="reset_button">
-       <property name="text">
-        <string>Reset View</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkbox_axes">
-       <property name="text">
-        <string>Coordinate axes</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item row="7" column="3" colspan="3">
     <widget class="QComboBox" name="combo_z_attribute"/>
@@ -262,6 +241,27 @@
       <string>stretch:</string>
      </property>
     </widget>
+   </item>
+   <item row="10" column="2" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="reset_button">
+       <property name="text">
+        <string>Reset View</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_axes">
+       <property name="text">
+        <string>Coordinate axes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>436</width>
-    <height>367</height>
+    <width>327</width>
+    <height>279</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,26 +20,6 @@
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="4" column="2" colspan="5">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>y axis</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="5">
     <widget class="QLineEdit" name="value_x_stretch">
      <property name="alignment">
@@ -47,10 +27,91 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="8" column="3">
+    <widget class="QLineEdit" name="value_z_min"/>
+   </item>
+   <item row="6" column="3" colspan="2">
+    <widget class="QSlider" name="slider_y_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="3" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="reset_button">
+       <property name="text">
+        <string>Reset View</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_axes">
+       <property name="text">
+        <string>Coordinate axes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_z_attribute"/>
+   </item>
+   <item row="6" column="2">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="3" colspan="2">
+    <widget class="QSlider" name="slider_z_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -70,71 +131,7 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="2" colspan="5">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_z_attribute"/>
-   </item>
-   <item row="1" column="4">
-    <widget class="QToolButton" name="button_flip_x">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="3" colspan="2">
-    <widget class="QSlider" name="slider_z_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="5">
-    <widget class="QLineEdit" name="value_y_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="value_x_min"/>
-   </item>
-   <item row="5" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_y_attribute"/>
-   </item>
-   <item row="0" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_x_attribute"/>
-   </item>
-   <item row="0" column="2">
+   <item row="4" column="2">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -143,84 +140,14 @@
       </font>
      </property>
      <property name="text">
-      <string>x axis</string>
+      <string>y axis</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
+   <item row="0" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_x_attribute"/>
    </item>
-   <item row="10" column="3">
-    <widget class="QLineEdit" name="value_z_min"/>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLineEdit" name="value_x_max"/>
-   </item>
-   <item row="10" column="5">
-    <widget class="QLineEdit" name="value_z_max"/>
-   </item>
-   <item row="8" column="2" colspan="5">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3">
-    <widget class="QLineEdit" name="value_y_min"/>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="5">
-    <widget class="QLineEdit" name="value_y_max"/>
-   </item>
-   <item row="7" column="3" colspan="2">
-    <widget class="QSlider" name="slider_y_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="2" colspan="5">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2">
+   <item row="7" column="2">
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
@@ -233,35 +160,17 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="5">
-    <widget class="QLineEdit" name="value_z_stretch">
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="value_y_min"/>
+   </item>
+   <item row="6" column="5">
+    <widget class="QLineEdit" name="value_y_stretch">
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="17" column="2" colspan="4">
-    <widget class="QPushButton" name="reset_button">
-     <property name="text">
-      <string>Reset View</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="3" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="checkbox_axes">
-       <property name="text">
-        <string>Coordinate axes</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="4">
+   <item row="8" column="4">
     <widget class="QToolButton" name="button_flip_z">
      <property name="font">
       <font>
@@ -276,7 +185,46 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="4">
+   <item row="1" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="5">
+    <widget class="QLineEdit" name="value_z_max"/>
+   </item>
+   <item row="5" column="5">
+    <widget class="QLineEdit" name="value_y_max"/>
+   </item>
+   <item row="8" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="4" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_y_attribute"/>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="4">
     <widget class="QToolButton" name="button_flip_y">
      <property name="font">
       <font>
@@ -288,6 +236,30 @@
      </property>
      <property name="text">
       <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="value_x_min"/>
+   </item>
+   <item row="9" column="5">
+    <widget class="QLineEdit" name="value_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
      </property>
     </widget>
    </item>

--- a/glue_vispy_viewers/isosurface/layer_style_widget.ui
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.ui
@@ -6,14 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>405</width>
-    <height>187</height>
+    <width>212</width>
+    <height>83</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="verticalSpacing">
+    <number>5</number>
+   </property>
+   <property name="margin">
+    <number>5</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Attribute:</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1">
     <widget class="QColorBox" name="label_color">
      <property name="sizePolicy">
@@ -27,15 +40,8 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combo_attribute"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Attribute:</string>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="value_min"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_2">
@@ -47,11 +53,11 @@
    <item row="1" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Level:</string>
+      <string>Limits:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
+   <item row="2" column="2">
     <widget class="QSlider" name="slider_alpha">
      <property name="maximum">
       <number>100</number>
@@ -61,15 +67,11 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Alpha:</string>
-     </property>
-    </widget>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="value_max"/>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="value_level"/>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combo_attribute"/>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -11,6 +11,7 @@ from glue.external.qt import QtGui
 from glue.utils.qt import load_ui, update_combobox, connect_color
 from glue.utils.qt.widget_properties import (ValueProperty,
                                              CurrentComboProperty,
+                                             CurrentComboTextProperty,
                                              FloatLineProperty,
                                              connect_float_edit,
                                              connect_current_combo,
@@ -21,6 +22,7 @@ from glue.utils.qt.widget_properties import (ValueProperty,
 class ScatterLayerStyleWidget(QtGui.QWidget):
 
     # Size-related GUI elements
+    size_mode = CurrentComboTextProperty('ui.combo_size_mode')
     size_attribute = CurrentComboProperty('ui.combo_size_attribute')
     size_vmin = FloatLineProperty('ui.value_size_vmin')
     size_vmax = FloatLineProperty('ui.value_size_vmax')
@@ -28,6 +30,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
     size_scaling = ValueProperty('ui.slider_size_scaling')
 
     # Color-related GUI elements
+    color_mode = CurrentComboTextProperty('ui.combo_color_mode')
     cmap_attribute = CurrentComboProperty('ui.combo_cmap_attribute')
     cmap_vmin = FloatLineProperty('ui.value_cmap_vmin')
     cmap_vmax = FloatLineProperty('ui.value_cmap_vmax')
@@ -53,15 +56,18 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.layer_artist.size = self.layer.style.markersize
         self.layer_artist.size_scaling = 1
         self.layer_artist.size_mode = 'fixed'
-        self.ui.radio_size_fixed.setChecked(True)
+        self.size_mode = 'Fixed'
         self.layer_artist.color = self.layer.style.color
         self.layer_artist.alpha = self.layer.style.alpha
         self.layer_artist.color_mode = 'fixed'
-        self.ui.radio_color_fixed.setChecked(True)
+        self.color_mode = 'Fixed'
         self.ui.combo_size_attribute.setCurrentIndex(0)
         self.ui.combo_cmap_attribute.setCurrentIndex(0)
         self.ui.combo_cmap.setCurrentIndex(0)
         self.layer_artist.visible = True
+
+        self._update_size_mode()
+        self._update_color_mode()
 
     def _connect_global(self):
         connect_float_edit(self.layer.style, 'markersize', self.ui.value_fixed_size)
@@ -73,11 +79,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         pass
 
     def _setup_size_options(self):
-
-        # Set up radio buttons for size mode selection
-        self._radio_size = QtGui.QButtonGroup()
-        self._radio_size.addButton(self.ui.radio_size_fixed)
-        self._radio_size.addButton(self.ui.radio_size_linear)
 
         # Set up attribute list
         label_data = [(comp.label, comp) for comp in self.visible_components]
@@ -91,16 +92,23 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         connect_value(self.layer_artist, 'size_scaling', self.ui.slider_size_scaling, value_range=(0.1, 10), log=True)
 
         # Set up internal connections
-        self.ui.radio_size_fixed.toggled.connect(self._update_size_mode)
-        self.ui.radio_size_linear.toggled.connect(self._update_size_mode)
+        self.ui.combo_size_mode.currentIndexChanged.connect(self._update_size_mode)
         self.ui.combo_size_attribute.currentIndexChanged.connect(self._update_size_limits)
         self.ui.button_flip_size.clicked.connect(self._flip_size)
 
     def _update_size_mode(self):
-        if self.ui.radio_size_fixed.isChecked():
-            self.layer_artist.size_mode = 'fixed'
+
+        self.layer_artist.size_mode = self.size_mode.lower()
+
+        if self.size_mode == "Fixed":
+            self.ui.size_row_2.hide()
+            self.ui.combo_size_attribute.hide()
+            self.ui.value_fixed_size.show()
         else:
-            self.layer_artist.size_mode = 'linear'
+            self.ui.value_fixed_size.hide()
+            self.ui.combo_size_attribute.show()
+            self.ui.size_row_2.show()
+
 
     def _update_size_limits(self):
 
@@ -118,11 +126,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
 
     def _setup_color_options(self):
 
-        # Set up radio buttons for color mode selection
-        self._radio_color = QtGui.QButtonGroup()
-        self._radio_color.addButton(self.ui.radio_color_fixed)
-        self._radio_color.addButton(self.ui.radio_color_linear)
-
         # Set up attribute list
         label_data = [(comp.label, comp) for comp in self.visible_components]
         update_combobox(self.ui.combo_cmap_attribute, label_data)
@@ -136,16 +139,26 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         connect_value(self.layer_artist, 'alpha', self.ui.slider_alpha, value_range=(0, 1))
 
         # Set up internal connections
-        self.ui.radio_color_fixed.toggled.connect(self._update_color_mode)
-        self.ui.radio_color_linear.toggled.connect(self._update_color_mode)
+        self.ui.combo_color_mode.currentIndexChanged.connect(self._update_color_mode)
         self.ui.combo_cmap_attribute.currentIndexChanged.connect(self._update_cmap_limits)
         self.ui.button_flip_cmap.clicked.connect(self._flip_cmap)
 
     def _update_color_mode(self):
-        if self.ui.radio_color_fixed.isChecked():
-            self.layer_artist.color_mode = 'fixed'
+
+        self.layer_artist.color_mode = self.color_mode.lower()
+
+        if self.color_mode == "Fixed":
+            self.ui.color_row_2.hide()
+            self.ui.color_row_3.hide()
+            self.ui.combo_cmap_attribute.hide()
+            self.ui.spacer_color_label.show()
+            self.ui.label_color.show()
         else:
-            self.layer_artist.color_mode = 'linear'
+            self.ui.label_color.hide()
+            self.ui.combo_cmap_attribute.show()
+            self.ui.spacer_color_label.hide()
+            self.ui.color_row_2.show()
+            self.ui.color_row_3.show()
 
     def _update_cmap_limits(self):
 
@@ -178,3 +191,53 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
             return self.layer.data.visible_components
         else:
             return self.layer.visible_components
+
+
+if __name__ == "__main__":
+
+    from glue.external.qt import get_qapp
+    from glue.external.echo import CallbackProperty
+
+    app = get_qapp()
+
+    class Style(object):
+        color = CallbackProperty("#334455")
+        alpha = CallbackProperty(1.0)
+        markersize = CallbackProperty(4)
+
+    class Component(object):
+        def __init__(self, label):
+            self.label = label
+
+    c1 = Component('a')
+    c2 = Component('b')
+    c3 = Component('c')
+
+    class Layer(object):
+        style = Style()
+        visible_components = [c1, c2, c3]
+
+    class LayerArtist(object):
+        layer = Layer()
+
+        size_mode = CallbackProperty(None)
+        size = CallbackProperty()
+        size_attribute = CallbackProperty()
+        size_vmin = CallbackProperty()
+        size_vmax = CallbackProperty()
+        size_scaling = CallbackProperty()
+
+        color_mode = CallbackProperty(None)
+        color = CallbackProperty()
+        cmap_attribute = CallbackProperty()
+        cmap_vmin = CallbackProperty()
+        cmap_vmax = CallbackProperty()
+        cmap = CallbackProperty()
+        alpha = CallbackProperty()
+
+    layer_artist = LayerArtist()
+
+    widget = ScatterLayerStyleWidget(layer_artist)
+    widget.show()
+
+    app.exec_()

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>275</width>
-    <height>157</height>
+    <width>259</width>
+    <height>146</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,8 +30,17 @@
        <property name="spacing">
         <number>2</number>
        </property>
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
        <property name="bottomMargin">
-        <number>5</number>
+        <number>3</number>
        </property>
        <item>
         <widget class="QWidget" name="size_row_1" native="true">
@@ -158,8 +167,17 @@
        <property name="spacing">
         <number>2</number>
        </property>
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
        <property name="bottomMargin">
-        <number>5</number>
+        <number>3</number>
        </property>
        <item>
         <widget class="QWidget" name="color_row_1" native="true">

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -6,170 +6,286 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>349</height>
+    <width>275</width>
+    <height>157</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0">
-    <widget class="QRadioButton" name="radio_color_linear">
-     <property name="text">
-      <string>Linear</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QRadioButton" name="radio_size_linear">
-     <property name="text">
-      <string>Linear</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QRadioButton" name="radio_size_fixed">
-     <property name="text">
-      <string>Fixed</string>
-     </property>
-    </widget>
-   </item>
+   <property name="margin">
+    <number>5</number>
+   </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <property name="text">
-      <string>Size</string>
-     </property>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Size</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="QWidget" name="size_row_1" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QComboBox" name="combo_size_mode">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <item>
+             <property name="text">
+              <string>Fixed</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Linear</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="combo_size_attribute"/>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="value_fixed_size"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="size_row_2" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLineEdit" name="value_size_vmin"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="button_flip_size">
+            <property name="font">
+             <font>
+              <pointsize>14</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">padding: 0px</string>
+            </property>
+            <property name="text">
+             <string>⇄</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="value_size_vmax"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="size_row_3" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QSlider" name="slider_size_scaling">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>50</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>Color</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="QWidget" name="color_row_1" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QComboBox" name="combo_color_mode">
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <item>
+             <property name="text">
+              <string>Fixed</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Linear</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="combo_cmap_attribute"/>
+          </item>
+          <item>
+           <widget class="QColorBox" name="label_color">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="spacer_color_label" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="color_row_2" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLineEdit" name="value_cmap_vmin"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="button_flip_cmap">
+            <property name="font">
+             <font>
+              <pointsize>14</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">padding: 0px</string>
+            </property>
+            <property name="text">
+             <string>⇄</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="value_cmap_vmax"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="color_row_3" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <property name="spacing">
+           <number>7</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QColormapCombo" name="combo_cmap"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSlider" name="slider_alpha">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLineEdit" name="value_cmap_vmin"/>
-   </item>
-   <item row="6" column="1">
-    <widget class="QColorBox" name="label_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="value_fixed_size"/>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Alpha:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="value_size_vmin"/>
-   </item>
-   <item row="6" column="0">
-    <widget class="QRadioButton" name="radio_color_fixed">
-     <property name="text">
-      <string>Fixed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-       <widget class="QToolButton" name="button_flip_size">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">padding: 0px</string>
-        </property>
-        <property name="text">
-         <string>⇄</string>
-        </property>
-       </widget>
-   </item>
-   <item row="3" column="3">
-    <widget class="QLineEdit" name="value_size_vmax"/>
-   </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QComboBox" name="combo_size_attribute"/>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QSlider" name="slider_size_scaling">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>50</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="3">
-    <widget class="QComboBox" name="combo_cmap_attribute"/>
-   </item>
-   <item row="8" column="3">
-    <widget class="QLineEdit" name="value_cmap_vmax"/>
-   </item>
-   <item row="13" column="1" colspan="3">
-    <widget class="QColormapCombo" name="combo_cmap"/>
-   </item>
-   <item row="14" column="1" colspan="3">
-    <widget class="QSlider" name="slider_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="2">
-       <widget class="QToolButton" name="button_flip_cmap">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">padding: 0px</string>
-        </property>
-        <property name="text">
-         <string>⇄</string>
-        </property>
-       </widget>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/volume/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/layer_style_widget.ui
@@ -6,29 +6,29 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>405</width>
-    <height>187</height>
+    <width>212</width>
+    <height>104</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="value_min"/>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_5">
+   <property name="verticalSpacing">
+    <number>5</number>
+   </property>
+   <property name="margin">
+    <number>5</number>
+   </property>
+   <item row="3" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
      <property name="text">
-      <string>Max:</string>
+      <string>Data</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="value_max"/>
-   </item>
-   <item row="0" column="1" colspan="3">
-    <widget class="QComboBox" name="combo_attribute"/>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="value_min"/>
    </item>
    <item row="2" column="1">
     <widget class="QColorBox" name="label_color">
@@ -60,11 +60,18 @@
    <item row="1" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Min:</string>
+      <string>Limits:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="3">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_subset_mode">
+     <property name="text">
+      <string>Subset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
     <widget class="QSlider" name="slider_alpha">
      <property name="maximum">
       <number>100</number>
@@ -74,31 +81,16 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Alpha:</string>
-     </property>
-    </widget>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="value_max"/>
    </item>
-   <item row="4" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combo_attribute"/>
    </item>
-   <item row="4" column="2" colspan="2">
+   <item row="3" column="2">
     <widget class="QRadioButton" name="radio_subset_outline">
      <property name="text">
       <string>Outline</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_subset_mode">
-     <property name="text">
-      <string>Subset:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This should make it so the scroll bars are no longer needed in the main application (since they were causing issues):

<img width="1554" alt="screen shot 2016-04-19 at 4 48 40 pm" src="https://cloud.githubusercontent.com/assets/314716/14645684/9125095e-064e-11e6-8dd1-eb40b6794745.png">
