### PR TITLE
Add initial support for saving 3D viewers to session files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 - Fix issue with _update_data on base VisPy viewer. [#106]
 
+- Implement support for saving 3D viewers in session files. [#130]
+
 - Optimize the layout of options for the layer style editors to save space. [#120]
 
 - Added the ability to save static images of the 3D viewers. [#125]

--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -28,6 +28,8 @@ class VispyOptionsWidget(QtGui.QWidget):
     z_max = FloatLineProperty('ui.value_z_max')
     z_stretch = FloatLineProperty('ui.value_z_stretch')
 
+    visible_box = ButtonProperty('ui.checkbox_axes')
+
     def __init__(self, parent=None, vispy_widget=None, data_viewer=None):
 
         super(VispyOptionsWidget, self).__init__(parent=parent)

--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -236,3 +236,15 @@ class VispyOptionsWidget(QtGui.QWidget):
             slider.setValue(1e4 * math.log10(float(label.text())))
         finally:
             self._event_lock = False
+
+    def __gluestate__(self, context):
+        return dict(x_att=context.id(self.x_att),
+                    x_min=self.x_min, x_max=self.x_max,
+                    x_stretch=self.x_stretch,
+                    y_att=context.id(self.y_att),
+                    y_min=self.y_min, y_max=self.y_max,
+                    y_stretch=self.y_stretch,
+                    z_att=context.id(self.z_att),
+                    z_min=self.z_min, z_max=self.z_max,
+                    z_stretch=self.z_stretch,
+                    visible_box=self.visible_box)

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -92,23 +92,8 @@ class BaseVispyViewer(DataViewer):
         return self.LABEL
 
     def __gluestate__(self, context):
-
         state = super(BaseVispyViewer, self).__gluestate__(context)
-
-        state['options'] = dict(x_att=context.id(self._options_widget.x_att),
-                                x_min=self._options_widget.x_min,
-                                x_max=self._options_widget.x_max,
-                                x_stretch=self._options_widget.x_stretch,
-                                y_att=context.id(self._options_widget.y_att),
-                                y_min=self._options_widget.y_min,
-                                y_max=self._options_widget.y_max,
-                                y_stretch=self._options_widget.y_stretch,
-                                z_att=context.id(self._options_widget.z_att),
-                                z_min=self._options_widget.z_min,
-                                z_max=self._options_widget.z_max,
-                                z_stretch=self._options_widget.z_stretch,
-                                visible_box=self._options_widget.visible_box)
-
+        state['options'] = self._options_widget.__gluestate__(context)
         return state
 
     @classmethod
@@ -116,8 +101,10 @@ class BaseVispyViewer(DataViewer):
 
         viewer = super(BaseVispyViewer, cls).__setgluestate__(rec, context)
 
+        from ..scatter.layer_artist import ScatterLayerArtist
+
         for layer_artist in viewer.layers:
-            if isinstance(layer_artist.layer, Data):
+            if isinstance(layer_artist, ScatterLayerArtist) and isinstance(layer_artist.layer, Data):
                 viewer._options_widget._update_attributes_from_data(layer_artist.layer)
 
         for attr in sorted(rec['options'], key=lambda x: 0 if 'att' in x else 1):

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -95,9 +95,19 @@ class BaseVispyViewer(DataViewer):
 
         state = super(BaseVispyViewer, self).__gluestate__(context)
 
-        state['options'] = dict(x_att=context.id(self._options_widget.x_att), x_min=self._options_widget.x_min, x_max=self._options_widget.x_max, x_stretch=self._options_widget.x_stretch,
-                                y_att=context.id(self._options_widget.y_att), y_min=self._options_widget.y_min, y_max=self._options_widget.y_max, y_stretch=self._options_widget.y_stretch,
-                                z_att=context.id(self._options_widget.z_att), z_min=self._options_widget.z_min, z_max=self._options_widget.z_max, z_stretch=self._options_widget.z_stretch)
+        state['options'] = dict(x_att=context.id(self._options_widget.x_att),
+                                x_min=self._options_widget.x_min,
+                                x_max=self._options_widget.x_max,
+                                x_stretch=self._options_widget.x_stretch,
+                                y_att=context.id(self._options_widget.y_att),
+                                y_min=self._options_widget.y_min,
+                                y_max=self._options_widget.y_max,
+                                y_stretch=self._options_widget.y_stretch,
+                                z_att=context.id(self._options_widget.z_att),
+                                z_min=self._options_widget.z_min,
+                                z_max=self._options_widget.z_max,
+                                z_stretch=self._options_widget.z_stretch,
+                                visible_box=self._options_widget.visible_box)
 
         return state
 
@@ -110,10 +120,8 @@ class BaseVispyViewer(DataViewer):
             if isinstance(layer_artist.layer, Data):
                 viewer._options_widget._update_attributes_from_data(layer_artist.layer)
 
-        for attr in rec['options']:
+        for attr in sorted(rec['options'], key=lambda x: 0 if 'att' in x else 1):
             value = rec['options'][attr]
-            if attr in ['x_att', 'y_att', 'z_att']:
-                value = context.object(value)
-            setattr(viewer._options_widget, attr, value)
+            setattr(viewer._options_widget, attr, context.object(value))
 
         return viewer

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -4,10 +4,10 @@ except ImportError:
     from glue.qt.widgets.data_viewer import DataViewer
 
 from glue.core import message as msg
+from glue.core import Data
 
 from .vispy_widget import VispyWidget
 from .viewer_options import VispyOptionsWidget
-from .toolbar import VispyDataViewerToolbar
 
 
 class BaseVispyViewer(DataViewer):
@@ -107,7 +107,8 @@ class BaseVispyViewer(DataViewer):
         viewer = super(BaseVispyViewer, cls).__setgluestate__(rec, context)
 
         for layer_artist in viewer.layers:
-            viewer._options_widget._update_attributes_from_data(layer_artist.layer)
+            if isinstance(layer_artist.layer, Data):
+                viewer._options_widget._update_attributes_from_data(layer_artist.layer)
 
         for attr in rec['options']:
             value = rec['options'][attr]

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -90,3 +90,29 @@ class BaseVispyViewer(DataViewer):
     @property
     def window_title(self):
         return self.LABEL
+
+    def __gluestate__(self, context):
+
+        state = super(BaseVispyViewer, self).__gluestate__(context)
+
+        state['options'] = dict(x_att=context.id(self._options_widget.x_att), x_min=self._options_widget.x_min, x_max=self._options_widget.x_max, x_stretch=self._options_widget.x_stretch,
+                                y_att=context.id(self._options_widget.y_att), y_min=self._options_widget.y_min, y_max=self._options_widget.y_max, y_stretch=self._options_widget.y_stretch,
+                                z_att=context.id(self._options_widget.z_att), z_min=self._options_widget.z_min, z_max=self._options_widget.z_max, z_stretch=self._options_widget.z_stretch)
+
+        return state
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+
+        viewer = super(BaseVispyViewer, cls).__setgluestate__(rec, context)
+
+        for layer_artist in viewer.layers:
+            viewer._options_widget._update_attributes_from_data(layer_artist.layer)
+
+        for attr in rec['options']:
+            value = rec['options'][attr]
+            if attr in ['x_att', 'y_att', 'z_att']:
+                value = context.object(value)
+            setattr(viewer._options_widget, attr, value)
+
+        return viewer

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -169,6 +169,7 @@ class ScatterLayerArtist(LayerArtistBase):
         self._update_data()
 
     def _update_data(self):
+
         try:
             x = self.layer[self._x_coord]
             y = self.layer[self._y_coord]
@@ -177,8 +178,18 @@ class ScatterLayerArtist(LayerArtistBase):
             x = np.array([])
             y = np.array([])
             z = np.array([])
+
         self._marker_data = np.array([x, y, z]).transpose()
-        self._multiscat.set_data_values(self.id, x, y, z)
+
+        # We need to make sure we update the sizes and colors in case
+        # these were set as arrays, since the size of the data might have
+        # changed (in the case of subsets)
+
+        with self._multiscat.delay_update():
+            self._multiscat.set_data_values(self.id, x, y, z)
+            self._update_sizes()
+            self._update_colors()
+
         self.redraw()
 
     @property

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -28,7 +28,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
     size_vmin = FloatLineProperty('ui.value_size_vmin')
     size_vmax = FloatLineProperty('ui.value_size_vmax')
     size = FloatLineProperty('ui.value_fixed_size')
-    size_scaling = ValueProperty('ui.slider_size_scaling')
+    size_scaling = ValueProperty('ui.slider_size_scaling', value_range=(0.1, 10), log=True)
 
     # Color-related GUI elements
     color_mode = CurrentComboTextProperty('ui.combo_color_mode')

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -7,6 +7,7 @@ from matplotlib import cm
 
 from glue.core.subset import Subset
 from glue.external.qt import QtGui
+from glue.external.echo import add_callback
 
 from glue.utils.qt import load_ui, update_combobox, connect_color
 from glue.utils.qt.widget_properties import (ValueProperty,
@@ -85,6 +86,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         update_combobox(self.ui.combo_size_attribute, label_data)
 
         # Set up connections with layer artist
+        add_callback(self.layer_artist, 'size_mode', self._set_size_mode)
         connect_float_edit(self.layer_artist, 'size', self.ui.value_fixed_size)
         connect_current_combo(self.layer_artist, 'size_attribute', self.ui.combo_size_attribute)
         connect_float_edit(self.layer_artist, 'size_vmin', self.ui.value_size_vmin)
@@ -95,6 +97,12 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.combo_size_mode.currentIndexChanged.connect(self._update_size_mode)
         self.ui.combo_size_attribute.currentIndexChanged.connect(self._update_size_limits)
         self.ui.button_flip_size.clicked.connect(self._flip_size)
+
+    def _set_size_mode(self, size_mode):
+        if size_mode == 'linear':
+            self.ui.radio_size_linear.setChecked(True)
+        else:
+            self.ui.radio_size_fixed.setChecked(True)
 
     def _update_size_mode(self):
 
@@ -131,6 +139,7 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         update_combobox(self.ui.combo_cmap_attribute, label_data)
 
         # Set up connections with layer artist
+        add_callback(self.layer_artist, 'color_mode', self._set_color_mode)
         connect_color(self.layer_artist, 'color', self.ui.label_color)
         connect_current_combo(self.layer_artist, 'cmap_attribute', self.ui.combo_cmap_attribute)
         connect_float_edit(self.layer_artist, 'cmap_vmin', self.ui.value_cmap_vmin)
@@ -142,6 +151,12 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.combo_color_mode.currentIndexChanged.connect(self._update_color_mode)
         self.ui.combo_cmap_attribute.currentIndexChanged.connect(self._update_cmap_limits)
         self.ui.button_flip_cmap.clicked.connect(self._flip_cmap)
+
+    def _set_color_mode(self, color_mode):
+        if color_mode == 'linear':
+            self.ui.radio_color_linear.setChecked(True)
+        else:
+            self.ui.radio_color_fixed.setChecked(True)
 
     def _update_color_mode(self):
 

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -90,7 +90,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         update_combobox(self.ui.combo_size_attribute, label_data)
 
         # Set up connections with layer artist
-        add_callback(self.layer_artist, 'size_mode', self._set_size_mode)
         connect_float_edit(self.layer_artist, 'size', self.ui.value_fixed_size)
         connect_current_combo(self.layer_artist, 'size_attribute', self.ui.combo_size_attribute)
         connect_float_edit(self.layer_artist, 'size_vmin', self.ui.value_size_vmin)
@@ -101,12 +100,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.combo_size_mode.currentIndexChanged.connect(self._update_size_mode)
         self.ui.combo_size_attribute.currentIndexChanged.connect(self._update_size_limits)
         self.ui.button_flip_size.clicked.connect(self._flip_size)
-
-    def _set_size_mode(self, size_mode):
-        if size_mode == 'linear':
-            self.ui.radio_size_linear.setChecked(True)
-        else:
-            self.ui.radio_size_fixed.setChecked(True)
 
     def _update_size_mode(self):
 
@@ -143,7 +136,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         update_combobox(self.ui.combo_cmap_attribute, label_data)
 
         # Set up connections with layer artist
-        add_callback(self.layer_artist, 'color_mode', self._set_color_mode)
         connect_color(self.layer_artist, 'color', self.ui.label_color)
         connect_current_combo(self.layer_artist, 'cmap_attribute', self.ui.combo_cmap_attribute)
         connect_float_edit(self.layer_artist, 'cmap_vmin', self.ui.value_cmap_vmin)
@@ -155,12 +147,6 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
         self.ui.combo_color_mode.currentIndexChanged.connect(self._update_color_mode)
         self.ui.combo_cmap_attribute.currentIndexChanged.connect(self._update_cmap_limits)
         self.ui.button_flip_cmap.clicked.connect(self._flip_cmap)
-
-    def _set_color_mode(self, color_mode):
-        if color_mode == 'linear':
-            self.ui.radio_color_linear.setChecked(True)
-        else:
-            self.ui.radio_color_fixed.setChecked(True)
 
     def _update_color_mode(self):
 

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -28,7 +28,11 @@ class ScatterLayerStyleWidget(QtGui.QWidget):
     size_vmin = FloatLineProperty('ui.value_size_vmin')
     size_vmax = FloatLineProperty('ui.value_size_vmax')
     size = FloatLineProperty('ui.value_fixed_size')
-    size_scaling = ValueProperty('ui.slider_size_scaling', value_range=(0.1, 10), log=True)
+
+    try:
+        size_scaling = ValueProperty('ui.slider_size_scaling', value_range=(0.1, 10), log=True)
+    except TypeError:  # Glue < 0.8
+        size_scaling = ValueProperty('ui.slider_size_scaling')
 
     # Color-related GUI elements
     color_mode = CurrentComboTextProperty('ui.combo_color_mode')

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import numpy as np
 
 from vispy import scene
@@ -16,7 +18,14 @@ class MultiColorScatter(scene.visuals.Markers):
     def __init__(self, *args, **kwargs):
         self.layers = {}
         self._combined_data = None
+        self._skip_update = False
         super(MultiColorScatter, self).__init__(*args, **kwargs)
+
+    @contextmanager
+    def delay_update(self):
+        self._skip_update = True
+        yield
+        self._skip_update = False
 
     def allocate(self, label):
         if label in self.layers:
@@ -70,6 +79,9 @@ class MultiColorScatter(scene.visuals.Markers):
         self._update()
 
     def _update(self):
+
+        if self._skip_update:
+            return
 
         data = []
         colors = []
@@ -171,4 +183,3 @@ if __name__ == "__main__":
 
     canvas.show()
     app.run()
-

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -35,7 +35,7 @@ class VispyScatterViewer(BaseVispyViewer):
             return
 
         layer_artist = ScatterLayerArtist(subset, vispy_viewer=self._vispy_widget)
-        self._update_attributes(layer_artist, layer_artist)
+        self._update_attributes(layer_artist=layer_artist)
 
         self._layer_artist_container.append(layer_artist)
 

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -1,3 +1,5 @@
+from glue.core.state import lookup_class_with_patches
+
 from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import ScatterLayerArtist
 from .layer_style_widget import ScatterLayerStyleWidget
@@ -53,3 +55,16 @@ class VispyScatterViewer(BaseVispyViewer):
             artist.set_coordinates(self._options_widget.x_att,
                                    self._options_widget.y_att,
                                    self._options_widget.z_att)
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        viewer = super(VispyScatterViewer, cls).__setgluestate__(rec, context)
+        viewer._update_attributes()
+
+        return viewer
+    def restore_layers(self, layers, context):
+        for l in layers:
+            cls = lookup_class_with_patches(l.pop('_type'))
+            props = dict((k, context.object(v)) for k, v in l.items())
+            layer_artist = cls(props['layer'], vispy_viewer=self._vispy_widget)
+            self._layer_artist_container.append(layer_artist)

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -21,7 +21,7 @@ class VispyScatterViewer(BaseVispyViewer):
 
         self._options_widget._update_attributes_from_data(data)
 
-        layer_artist = ScatterLayerArtist(data, vispy_viewer=self._vispy_widget)
+        layer_artist = ScatterLayerArtist(data, vispy_viewer=self)
         self._update_attributes(layer_artist=layer_artist)
 
         self._layer_artist_container.append(layer_artist)
@@ -36,7 +36,7 @@ class VispyScatterViewer(BaseVispyViewer):
         if subset in self._layer_artist_container:
             return
 
-        layer_artist = ScatterLayerArtist(subset, vispy_viewer=self._vispy_widget)
+        layer_artist = ScatterLayerArtist(subset, vispy_viewer=self)
         self._update_attributes(layer_artist=layer_artist)
 
         self._layer_artist_container.append(layer_artist)
@@ -62,9 +62,11 @@ class VispyScatterViewer(BaseVispyViewer):
         viewer._update_attributes()
 
         return viewer
+
     def restore_layers(self, layers, context):
         for l in layers:
             cls = lookup_class_with_patches(l.pop('_type'))
             props = dict((k, context.object(v)) for k, v in l.items())
-            layer_artist = cls(props['layer'], vispy_viewer=self._vispy_widget)
+            layer_artist = cls(props['layer'], vispy_viewer=self)
             self._layer_artist_container.append(layer_artist)
+            layer_artist.set(**props)

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -60,7 +60,6 @@ class VispyScatterViewer(BaseVispyViewer):
     def __setgluestate__(cls, rec, context):
         viewer = super(VispyScatterViewer, cls).__setgluestate__(rec, context)
         viewer._update_attributes()
-
         return viewer
 
     def restore_layers(self, layers, context):

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -65,13 +65,13 @@ def test_scatter_viewer(tmpdir):
     layer_artist = scatter.layers[0]
     style_widget = scatter._view.layout_style_widgets[layer_artist]
 
-    style_widget._set_size_mode('linear')
+    style_widget.size_mode = 'Linear'
     style_widget.size_attribute = data.id['c']
     style_widget.size_scaling = 2
     style_widget.size_vmin = 0.2
     style_widget.size_vmax = 0.8
 
-    style_widget._set_color_mode('linear')
+    style_widget.color_mode = 'Linear'
     style_widget.cmap_attribute = data.id['y']
     style_widget.cmap_vmin = 0.1
     style_widget.cmap_vmax = 0.9

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -20,7 +20,8 @@ def make_test_data():
 
     return data
 
-def test_scatter_viewer():
+
+def test_scatter_viewer(tmpdir):
 
     # Create fake data
     data = make_test_data()
@@ -29,11 +30,13 @@ def test_scatter_viewer():
 
     dc = DataCollection([data])
     ga = GlueApplication(dc)
+    ga.show()
 
-    w = ga.new_data_viewer(VispyScatterViewer)
-    w.add_data(data)
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data)
+    scatter.viewer_size = (400, 500)
 
-    options = w.options_widget()
+    options = scatter.options_widget()
 
     options.x_att = data.id['a']
     options.y_att = data.id['f']
@@ -50,9 +53,11 @@ def test_scatter_viewer():
     options.z_min = 0.2
     options.z_max = 0.8
 
+    options.visible_box = False
+
     # Get layer artist style editor
-    layer_artist = list(w._view.layout_style_widgets.keys())[0]
-    style_widget = w._view.layout_style_widgets[layer_artist]
+    layer_artist = scatter.layers[0]
+    style_widget = scatter._view.layout_style_widgets[layer_artist]
 
     style_widget._set_size_mode('linear')
     style_widget.size_attribute = data.id['c']
@@ -65,3 +70,51 @@ def test_scatter_viewer():
     style_widget.cmap_vmin = 0.1
     style_widget.cmap_vmax = 0.9
     style_widget.cmap = cm.BuGn
+
+    # Check that writing a session works as expected
+
+    session_file = tmpdir.join('test_scatter_viewer.glu').strpath
+    ga.save_session(session_file)
+    ga.close()
+
+    # Now we can check that everything is restored correctly
+
+    ga2 = GlueApplication.restore_session(session_file)
+    ga2.show()
+
+    scatter_r = ga2.viewers[0][0]
+
+    assert scatter_r.viewer_size == (400, 500)
+
+    options = scatter_r.options_widget()
+
+    assert options.x_att.label == 'a'
+    assert options.y_att.label == 'f'
+    assert options.z_att.label == 'z'
+
+    assert options.x_stretch == 0.5
+    assert options.y_stretch == 1.0
+    assert options.z_stretch == 2.0
+
+    assert options.x_min == -0.1
+    assert options.x_max == 1.1
+    assert options.y_min == 0.1
+    assert options.y_max == 0.9
+    assert options.z_min == 0.2
+    assert options.z_max == 0.8
+
+    assert not options.visible_box
+
+    layer_artist = scatter_r.layers[0]
+
+    assert layer_artist.size_mode == 'linear'
+    assert layer_artist.size_attribute.label == 'c'
+    np.testing.assert_allclose(layer_artist.size_scaling, 2, rtol=0.01)
+    assert layer_artist.size_vmin == 0.2
+    assert layer_artist.size_vmax == 0.8
+
+    assert layer_artist.color_mode == 'linear'
+    assert layer_artist.cmap_attribute.label == 'y'
+    assert layer_artist.cmap_vmin == 0.1
+    assert layer_artist.cmap_vmax == 0.9
+    assert layer_artist.cmap is cm.BuGn

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -1,5 +1,8 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 
+import glue
 from glue.core import DataCollection, Data
 from glue.app.qt.application import GlueApplication
 from glue.core.component import Component
@@ -7,6 +10,9 @@ from glue.core.component import Component
 from matplotlib import cm
 
 from ..scatter_viewer import VispyScatterViewer
+
+GLUE_LT_08 = LooseVersion(glue.__version__) < LooseVersion('0.8')
+
 
 def make_test_data():
 
@@ -71,7 +77,12 @@ def test_scatter_viewer(tmpdir):
     style_widget.cmap_vmax = 0.9
     style_widget.cmap = cm.BuGn
 
-    # Check that writing a session works as expected
+    # Check that writing a session works as expected. However, this only
+    # works with Glue 0.8 and above, so we skip this test if we are using an
+    # older version.
+
+    if GLUE_LT_08:
+        return
 
     session_file = tmpdir.join('test_scatter_viewer.glu').strpath
     ga.save_session(session_file)

--- a/glue_vispy_viewers/volume/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/layer_style_widget.py
@@ -23,7 +23,7 @@ class VolumeLayerStyleWidget(QtGui.QWidget):
     attribute = CurrentComboProperty('ui.combo_attribute')
     vmin = FloatLineProperty('ui.value_min')
     vmax = FloatLineProperty('ui.value_max')
-    alpha = ValueProperty('ui.slider_alpha')
+    alpha = ValueProperty('ui.slider_alpha', value_range=(0, 1))
     subset_outline = ButtonProperty('ui.radio_subset_outline')
     subset_data = ButtonProperty('ui.radio_subset_data')
 

--- a/glue_vispy_viewers/volume/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/tests/test_volume_viewer.py
@@ -1,22 +1,100 @@
 import numpy as np
 
-from glue.core import Data
-from glue.core.tests.util import simple_session
+from glue.core import DataCollection, Data
+from glue.app.qt.application import GlueApplication
+from glue.core.component import Component
+
+from matplotlib import cm
 
 from ..volume_viewer import VispyVolumeViewer
 
+def make_test_data():
 
-def test_volume_viewer():
+    data = Data(label="Test Cube Data")
+
+    np.random.seed(12345)
+
+    for letter in 'abc':
+        comp = Component(np.random.random((10,10,10)))
+        data.add_component(comp, letter)
+
+    return data
+
+
+def test_volume_viewer(tmpdir):
 
     # Create fake data
-    data = Data(primary=np.arange(1000).reshape((10,10,10)))
+    data = make_test_data()
 
     # Create fake session
-    session = simple_session()
-    session.data_collection.append(data)
 
-    w = VispyVolumeViewer(session)
-    w.add_data(data)
-    w.show()
+    dc = DataCollection([data])
+    ga = GlueApplication(dc)
+    ga.show()
 
-    # TODO: add tests for visual options
+    volume = ga.new_data_viewer(VispyVolumeViewer)
+    volume.add_data(data)
+    volume.viewer_size = (400, 500)
+
+    options = volume.options_widget()
+
+    options.x_stretch = 0.5
+    options.y_stretch = 1.0
+    options.z_stretch = 2.0
+
+    options.x_min = -0.1
+    options.x_max = 10.1
+    options.y_min = 0.1
+    options.y_max = 10.9
+    options.z_min = 0.2
+    options.z_max = 10.8
+
+    options.visible_box = False
+
+    # Get layer artist style editor
+    layer_artist = volume.layers[0]
+    style_widget = volume._view.layout_style_widgets[layer_artist]
+
+    style_widget.attribute = data.id['b']
+    style_widget.vmin = 0.1
+    style_widget.vmax = 0.9
+    style_widget.alpha = 0.8
+
+    # Check that writing a session works as expected
+
+    session_file = tmpdir.join('test_volume_viewer.glu').strpath
+    ga.save_session(session_file)
+    ga.close()
+
+    # Now we can check that everything is restored correctly
+
+    ga2 = GlueApplication.restore_session(session_file)
+    ga2.show()
+
+    volume_r = ga2.viewers[0][0]
+
+    assert volume_r.viewer_size == (400, 500)
+
+    options = volume_r.options_widget()
+
+    assert options.x_stretch == 0.5
+    assert options.y_stretch == 1.0
+    assert options.z_stretch == 2.0
+
+    assert options.x_min == -0.1
+    assert options.x_max == 10.1
+    assert options.y_min == 0.1
+    assert options.y_max == 10.9
+    assert options.z_min == 0.2
+    assert options.z_max == 10.8
+
+    assert not options.visible_box
+
+    layer_artist = volume_r.layers[0]
+
+    assert style_widget.attribute.label == 'b'
+    assert style_widget.vmin == 0.1
+    assert style_widget.vmax == 0.9
+    assert style_widget.alpha == 0.8
+    
+    ga2.close()

--- a/glue_vispy_viewers/volume/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/tests/test_volume_viewer.py
@@ -1,5 +1,9 @@
+from distutils.version import LooseVersion
+
+import pytest
 import numpy as np
 
+import glue
 from glue.core import DataCollection, Data
 from glue.app.qt.application import GlueApplication
 from glue.core.component import Component
@@ -7,6 +11,9 @@ from glue.core.component import Component
 from matplotlib import cm
 
 from ..volume_viewer import VispyVolumeViewer
+
+GLUE_LT_08 = LooseVersion(glue.__version__) < LooseVersion('0.8')
+
 
 def make_test_data():
 
@@ -60,7 +67,7 @@ def test_volume_viewer(tmpdir):
     style_widget.vmax = 0.9
     style_widget.alpha = 0.8
 
-    # Check that writing a session works as expected
+    # Check that writing a session works as expected.
 
     session_file = tmpdir.join('test_volume_viewer.glu').strpath
     ga.save_session(session_file)
@@ -96,5 +103,5 @@ def test_volume_viewer(tmpdir):
     assert style_widget.vmin == 0.1
     assert style_widget.vmax == 0.9
     assert style_widget.alpha == 0.8
-    
+
     ga2.close()


### PR DESCRIPTION
This should work for the scatter and volume viewers (will add the isosurface viewer). However, saving the scatter plot viewers will require the latest developer version of glue with some new fixes.

Closes #111
