### PR TITLE
Make sure the 3D viewer is updated if the zorder is set manually

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
 - Implemented 3D selection. [#103]
 
+- Make sure the 3D viewer is updated if the zorder is set manually. [#132]
+
 - Add selection toolbar and icons for 3D viewers. [#88] [#92] 
 
 0.2 (2015-03-11)

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -100,6 +100,15 @@ class ScatterLayerArtist(LayerArtistBase):
     def get_zorder(self):
         return self.zorder
 
+    @property
+    def zorder(self):
+        return self._zorder
+
+    @zorder.setter
+    def zorder(self, value):
+        self._zorder = value
+        self.redraw()
+
     def redraw(self):
         """
         Redraw the Vispy canvas


### PR DESCRIPTION
This fixes the issue that when a subset is added manually, the zorder is incorrect initially (we need to force a redraw)
