### PR TITLE
Raise an explicit error if pyopengl is not installed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Make sure an error is raised if data is not 3-dimensional and shape doesn’t
   agree with existing data in volume viewer. [#112]
 
+- Raise an explicit error if PyOpenGL is not installed. [#129]
+
 - Fix a bug that caused exceptions when clearing/removing layer artists. [#117]
 
 - Workaround OpenGL issue that caused cubes with size > 2048 along any

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -5,6 +5,13 @@ from .layer_artist import VolumeLayerArtist
 from .layer_style_widget import VolumeLayerStyleWidget
 from .volume_toolbar import VolumeSelectionToolbar
 
+try:
+    import OpenGL
+except ImportError:
+    OPENGL_INSTALLED = False
+else:
+    OPENGL_INSTALLED = True
+
 
 class VispyVolumeViewer(BaseVispyViewer):
 
@@ -12,6 +19,15 @@ class VispyVolumeViewer(BaseVispyViewer):
 
     _layer_style_widget_cls = VolumeLayerStyleWidget
     _toolbar_cls = VolumeSelectionToolbar
+
+    def __init__(self, *args, **kwargs):
+        super(VispyVolumeViewer, self).__init__(*args, **kwargs)
+        if not OPENGL_INSTALLED:
+            self.close()
+            QMessageBox.critical(self, "Error",
+                                 "The PyOpenGL package is required for the "
+                                 "3D volume rendering viewer",
+                                 buttons=QMessageBox.Ok)
 
     def add_data(self, data):
 


### PR DESCRIPTION
Otherwise the volume drawing fails silently. We should raise the error in the viewer `__init__`
