### PR TITLE
Show rayline when cursor click

### DIFF
--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -5,6 +5,7 @@ except ImportError:
 
 from glue.core import message as msg
 from glue.core import Data
+from glue.external.qt import QtGui, get_qapp
 
 from .vispy_widget import VispyWidget
 from .viewer_options import VispyOptionsWidget
@@ -23,6 +24,8 @@ class BaseVispyViewer(DataViewer):
 
         toolbar = self._toolbar_cls(vispy_widget=self._vispy_widget, parent=self)
         self.addToolBar(toolbar)
+
+        self.status_label = None
 
     def register_to_hub(self, hub):
 
@@ -127,3 +130,10 @@ class BaseVispyViewer(DataViewer):
             setattr(viewer._options_widget, attr, context.object(value))
 
         return viewer
+
+    def show_status(self, text):
+        if not self.status_label:
+            statusbar = self.statusBar()
+            self.status_label = QtGui.QLabel()
+            statusbar.addWidget(self.status_label)
+        self.status_label.setText(text)

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -61,7 +61,7 @@ class VispyWidget(QtGui.QWidget):
         # that here
 
         # Remove the fov=60 here to solve the mismatch of selection problem
-        self.view.camera = scene.cameras.TurntableCamera(parent=self.view.scene, fov=60, distance=2.0)
+        self.view.camera = scene.cameras.TurntableCamera(parent=self.view.scene, center=(0, 0, 0), fov=60, distance=2.0)
 
         # Add the native canvas widget to this widget
         layout = QtGui.QVBoxLayout()

--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -13,7 +13,8 @@ from ..extern.vispy import scene
 class VolumeSelectionToolbar(VispyDataViewerToolbar):
 
     def __init__(self, vispy_widget=None, parent=None):
-        super(VolumeSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
+        super(VolumeSelectionToolbar, self).__init__(vispy_widget=vispy_widget,
+                                                     parent=parent)
         self.trans_ones_data = None
         # add some markers
         self.markers = scene.visuals.Markers(parent=self._vispy_widget.view.scene)
@@ -21,24 +22,27 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
                                            parent=self._vispy_widget.view.scene)
 
         self.visual_tr = None
+        self.visible_data = None
+        self.visual = None
 
-# todo: add global variable of visual, vol_data, vol_shape
+
+# todo: add global variable of self.visual, vol_data, vol_shape
 
     def on_mouse_press(self, event):
         """
         Assign mouse position and do point selection.
         :param event:
         """
-        self.selection_origin = event.pos
+        if self.mode:
+            # do the initiation here
+            self.selection_origin = event.pos
+            self.visible_data, self.visual = self.get_visible_data()
+            data_array = self.visible_data[0]['PRIMARY']
+            self.visual_tr = self._vispy_widget.limit_transforms[self.visual]
+
         if self.mode is 'point':
-
-            visible_data, visual = self.get_visible_data()
-            data_object = visible_data[0]
-            data_array = data_object['PRIMARY']
-
-            trans = self._vispy_widget.limit_transforms[visual].translate
-            scale = self._vispy_widget.limit_transforms[visual].scale
-            self.visual_tr = self._vispy_widget.limit_transforms[visual]
+            trans = self.visual_tr.translate
+            scale = self.visual_tr.scale
 
             # get start and end point of ray line
             pos = self.get_ray_line()
@@ -80,6 +84,9 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             if len(inter_value) != 0:
                 self.markers.set_data(pos=np.array([inter_pos[np.argmax(inter_value)]]),
                                       face_color='yellow')
+                status_text = 'pos '+str(inter_pos[np.argmax(inter_value)]) \
+                              + ' value '+str(inter_value.max())
+                self._vispy_data_viewer.show_status(status_text)
 
             self._vispy_widget.canvas.update()
 
@@ -89,8 +96,7 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
         :param event:
         """
         # Get the visible data set
-        if event.button == 1 and self.mode and self.mode is not 'point':
-            visible_data, visual = self.get_visible_data()
+        if event.button == 1 and self.mode is not None:
             data = self.get_map_data()
 
             if len(self.line_pos) == 0:
@@ -102,16 +108,20 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
                 mask = selection_path.contains_points(data)
 
             elif self.mode is 'ellipse':
-                xmin, ymin = np.min(self.line_pos[:, 0]), np.min(self.line_pos[:, 1])
-                xmax, ymax = np.max(self.line_pos[:, 0]), np.max(self.line_pos[:, 1])
+                xmin, ymin = np.min(self.line_pos[:, 0]), \
+                             np.min(self.line_pos[:, 1])
+                xmax, ymax = np.max(self.line_pos[:, 0]), \
+                             np.max(self.line_pos[:, 1])
 
                 # (xc, yc, radius)
                 c = CircularROI((xmax+xmin)/2., (ymax+ymin)/2., (xmax-xmin)/2.)
                 mask = c.contains(data[:, 0], data[:, 1])
 
             elif self.mode is 'rectangle':
-                xmin, ymin = np.min(self.line_pos[:, 0]), np.min(self.line_pos[:, 1])
-                xmax, ymax = np.max(self.line_pos[:, 0]), np.max(self.line_pos[:, 1])
+                xmin, ymin = np.min(self.line_pos[:, 0]), \
+                             np.min(self.line_pos[:, 1])
+                xmax, ymax = np.max(self.line_pos[:, 0]), \
+                             np.max(self.line_pos[:, 1])
                 r = RectangularROI(xmin, xmax, ymin, ymax)
                 mask = r.contains(data[:, 0], data[:, 1])
 
@@ -122,24 +132,24 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             # The ravel here is to make mask compatible with ElementSubsetState input.
             new_mask = np.reshape(mask, self.trans_ones_data.shape)
             new_mask = np.ravel(np.transpose(new_mask))
-            self.mark_selected(new_mask, visible_data)
+            self.mark_selected(new_mask, self.visible_data)
 
             self.lasso_reset()
 
     def get_map_data(self):
         """
-        Get the mapped buffer from visual to canvas.
+        Get the mapped buffer from self.visual to canvas.
 
         :return: Mapped data position on canvas.
         """
 
         # Get the visible datasets
-        visible_data, visual = self.get_visible_data()
-        data_object = visible_data[0]
+        data_object = self.visible_data[0]
 
-        # TODO: add support for multiple data here, data_array should cover all visible_data array
+        # TODO: add support for multiple data here, data_array should
+        # cover all self.visible_data array
 
-        tr = visual.get_transform(map_from='visual', map_to='canvas')
+        tr = self.visual.get_transform(map_from='visual', map_to='canvas')
 
         self.trans_ones_data = np.transpose(np.ones(data_object.data.shape))
 
@@ -154,15 +164,15 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
 
         :return: Start point and end point position.
         """
-        visible_data, visual = self.get_visible_data()
-        tr_back = visual.get_transform(map_from='canvas', map_to='visual')
+        tr_back = self.visual.get_transform(map_from='canvas', map_to='visual')
 
         _cam = self._vispy_widget.view.camera
         start_point = _cam.transform.map(_cam.center)
 
         end_point = np.insert(self.selection_origin, 2, 1)
         end_point = tr_back.map(end_point)
-        # add the visual local transform
+
+        # add the self.visual local transform
         end_point = self.visual_tr.map(end_point)
         end_point = end_point[:3] / end_point[3]
 

--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -6,7 +6,9 @@ from ..common.toolbar import VispyDataViewerToolbar
 
 import numpy as np
 from matplotlib import path
+
 from glue.core.roi import RectangularROI, CircularROI
+from ..extern.vispy import scene
 
 
 class VolumeSelectionToolbar(VispyDataViewerToolbar):
@@ -14,19 +16,87 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
     def __init__(self, vispy_widget=None, parent=None):
         super(VolumeSelectionToolbar, self).__init__(vispy_widget=vispy_widget, parent=parent)
         self.trans_ones_data = None
+        # add some markers
+        self.markers = scene.visuals.Markers(parent=self._vispy_widget.view.scene)
+        self.trans = None
+        self.scale = None
+        self.visual_transform = None
+
+# todo: add global variable of visual, vol_data, vol_shape
 
     def on_mouse_press(self, event):
+        """
+        Assign mouse position and do point selection.
+        :param event:
+        """
         self.selection_origin = event.pos
+        print('event.pos', self.selection_origin)
         if self.mode is 'point':
-            # TODO: add dendrogram selection here
-            pass
+
+            visible_data, visual = self.get_visible_data()
+            data_object = visible_data[0]
+            data_array = data_object['PRIMARY']
+
+            self.trans = self._vispy_widget.limit_transforms[visual].translate
+            self.scale = self._vispy_widget.limit_transforms[visual].scale
+            self.visual_transform = self._vispy_widget.limit_transforms[visual]
+            print('visual transform', self.visual_transform)
+
+            pos = self.get_ray_line()
+
+            # find the intersected points position in visual coordinate through z axis
+            inter_pos = []
+
+            for z in range(0, data_array.shape[0]):
+                #   3D line defined with two points (x0, y0, z0) and (x1, y1, z1) as
+                #   (x - x1)/(x2 - x1) = (y - y1)/(y2 - y1) = (z - z1)/(z2 - z1) = t
+                z = z * self.scale[2] + self.trans[2]
+                t = (z - pos[0][2])/(pos[1][2] - pos[0][2])
+                x = t * (pos[1][0] - pos[0][0]) + pos[0][0]
+                y = t * (pos[1][1] - pos[0][1]) + pos[0][1]
+                inter_pos.append([x, y, z])
+            inter_pos = np.array(inter_pos)
+            # not correct here
+
+            # cut the line within the cube
+            m1 = inter_pos[:, 0] > self.trans[0] # or =?  for x
+            m2 = inter_pos[:, 0] < (data_array.shape[2] * self.scale[0] + self.trans[0])
+            m3 = inter_pos[:, 1] > self.trans[1]  # for y
+            m4 = inter_pos[:, 1] < (data_array.shape[1]*self.scale[1] + self.trans[1])
+            inter_pos = inter_pos[m1 & m2 & m3 & m4]
+
+            # set colors for markers
+            colors = np.ones((inter_pos.shape[0], 4))
+            colors[:] = (0.5, 0.5, 0, 1)
+
+            # value of intersected points
+            inter_value = []
+            for each_point in inter_pos:
+                x = (each_point[0] - self.trans[0])/self.scale[0]
+                y = (each_point[1] - self.trans[1])/self.scale[1]
+                z = (each_point[2] - self.trans[2])/self.scale[2]
+                inter_value.append(data_array[(z, y, x)])
+            inter_value = np.array(inter_value)
+            print('inter value, pos', inter_value.shape, inter_pos.shape)
+            assert inter_value.shape[0] == inter_pos.shape[0]
+            if len(inter_value) != 0:
+                colors[np.argmax(inter_value)] = (1, 1, 0.5, 1)  # change the color of max value marker
+
+            self.markers.set_data(pos=inter_pos, face_color=colors)
+            # print('interpos is', inter_points_index, data_array)
+            # update limit to make transform sync with the stretch  :)
+            # self._vispy_widget.add_data_visual(self.markers)
+            # self._vispy_widget._update_limits()
+            self._vispy_widget.canvas.update()
 
     def on_mouse_release(self, event):
-
-        visible_data, visual = self.get_visible_data()
+        """
+        Get the mask of selected data and get them highlighted.
+        :param event:
+        """
 
         # Get the visible datasets
-        if event.button == 1 and self.mode is not None:
+        if event.button == 1 and self.mode and self.mode is not 'point':
             visible_data, visual = self.get_visible_data()
             data = self.get_map_data()
 
@@ -62,18 +132,52 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             self.lasso_reset()
 
     def get_map_data(self):
+        """
+        Get the mapped buffer from visual to canvas.
+
+        :return: Mapped data position on canvas.
+        """
 
         # Get the visible datasets
         visible_data, visual = self.get_visible_data()
-        layer = visible_data[0]
+        data_object = visible_data[0]
 
-        # TODO: add support for multiple data here, layer should cover all visible_data array
+        # TODO: add support for multiple data here, data_array should cover all visible_data array
 
         tr = visual.get_transform(map_from='visual', map_to='canvas')
 
-        self.trans_ones_data = np.transpose(np.ones(layer.data.shape))
+        self.trans_ones_data = np.transpose(np.ones(data_object.data.shape))
 
         pos_data = np.argwhere(self.trans_ones_data)
         data = tr.map(pos_data)
         data /= data[:, 3:]   # normalize with homogeneous coordinates
         return data[:, :2]
+
+    def get_ray_line(self):
+        """
+        Get the ray line from camera pos to the far point.
+
+        :return: Start point and end point position.
+        """
+        visible_data, visual = self.get_visible_data()
+        tr_back = visual.get_transform(map_from='canvas', map_to='visual') # TODO: put visual to self.visual
+        print('=======================')
+        print('chain transform', tr_back)
+        print('=======================')
+
+        # try add the visual's transform
+        # tr_back = tr_back * self.visual_transform
+        print('chain transform after visual', tr_back)
+        print('=======================')
+
+        _cam = self._vispy_widget.view.camera
+        _cam_point = _cam.transform.map(_cam.center)  #TODO: this is not correct
+
+        trpos_start = np.insert(self.selection_origin, 2, 1)
+        trpos_start = tr_back.map(trpos_start)
+        trpos_start = self.visual_transform.map(trpos_start)
+        print('trpos_start after visual transform', trpos_start)
+
+        trpos_start = trpos_start[:3] / trpos_start[3]
+
+        return np.array([trpos_start, _cam_point[:3]])

--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -6,7 +6,6 @@ from ..common.toolbar import VispyDataViewerToolbar
 
 import numpy as np
 from matplotlib import path
-
 from glue.core.roi import RectangularROI, CircularROI
 from ..extern.vispy import scene
 
@@ -18,9 +17,10 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
         self.trans_ones_data = None
         # add some markers
         self.markers = scene.visuals.Markers(parent=self._vispy_widget.view.scene)
-        self.trans = None
-        self.scale = None
-        self.visual_transform = None
+        self.ray_line = scene.visuals.Line(color='green', width=5,
+                                           parent=self._vispy_widget.view.scene)
+
+        self.visual_tr = None
 
 # todo: add global variable of visual, vol_data, vol_shape
 
@@ -30,39 +30,35 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
         :param event:
         """
         self.selection_origin = event.pos
-        print('event.pos', self.selection_origin)
         if self.mode is 'point':
 
             visible_data, visual = self.get_visible_data()
             data_object = visible_data[0]
             data_array = data_object['PRIMARY']
 
-            self.trans = self._vispy_widget.limit_transforms[visual].translate
-            self.scale = self._vispy_widget.limit_transforms[visual].scale
-            self.visual_transform = self._vispy_widget.limit_transforms[visual]
-            print('visual transform', self.visual_transform)
+            trans = self._vispy_widget.limit_transforms[visual].translate
+            scale = self._vispy_widget.limit_transforms[visual].scale
+            self.visual_tr = self._vispy_widget.limit_transforms[visual]
 
+            # get start and end point of ray line
             pos = self.get_ray_line()
 
-            # find the intersected points position in visual coordinate through z axis
             inter_pos = []
-
             for z in range(0, data_array.shape[0]):
                 #   3D line defined with two points (x0, y0, z0) and (x1, y1, z1) as
                 #   (x - x1)/(x2 - x1) = (y - y1)/(y2 - y1) = (z - z1)/(z2 - z1) = t
-                z = z * self.scale[2] + self.trans[2]
+                z = z * scale[2] + trans[2]
                 t = (z - pos[0][2])/(pos[1][2] - pos[0][2])
                 x = t * (pos[1][0] - pos[0][0]) + pos[0][0]
                 y = t * (pos[1][1] - pos[0][1]) + pos[0][1]
                 inter_pos.append([x, y, z])
             inter_pos = np.array(inter_pos)
-            # not correct here
 
             # cut the line within the cube
-            m1 = inter_pos[:, 0] > self.trans[0] # or =?  for x
-            m2 = inter_pos[:, 0] < (data_array.shape[2] * self.scale[0] + self.trans[0])
-            m3 = inter_pos[:, 1] > self.trans[1]  # for y
-            m4 = inter_pos[:, 1] < (data_array.shape[1]*self.scale[1] + self.trans[1])
+            m1 = inter_pos[:, 0] > trans[0]  # for x
+            m2 = inter_pos[:, 0] < (data_array.shape[2] * scale[0] + trans[0])
+            m3 = inter_pos[:, 1] > trans[1]  # for y
+            m4 = inter_pos[:, 1] < (data_array.shape[1]*scale[1] + trans[1])
             inter_pos = inter_pos[m1 & m2 & m3 & m4]
 
             # set colors for markers
@@ -72,21 +68,19 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             # value of intersected points
             inter_value = []
             for each_point in inter_pos:
-                x = (each_point[0] - self.trans[0])/self.scale[0]
-                y = (each_point[1] - self.trans[1])/self.scale[1]
-                z = (each_point[2] - self.trans[2])/self.scale[2]
+                x = (each_point[0] - trans[0])/scale[0]
+                y = (each_point[1] - trans[1])/scale[1]
+                z = (each_point[2] - trans[2])/scale[2]
                 inter_value.append(data_array[(z, y, x)])
             inter_value = np.array(inter_value)
-            print('inter value, pos', inter_value.shape, inter_pos.shape)
-            assert inter_value.shape[0] == inter_pos.shape[0]
-            if len(inter_value) != 0:
-                colors[np.argmax(inter_value)] = (1, 1, 0.5, 1)  # change the color of max value marker
 
-            self.markers.set_data(pos=inter_pos, face_color=colors)
-            # print('interpos is', inter_points_index, data_array)
-            # update limit to make transform sync with the stretch  :)
-            # self._vispy_widget.add_data_visual(self.markers)
-            # self._vispy_widget._update_limits()
+            assert inter_value.shape[0] == inter_pos.shape[0]
+
+            # change the color of max value marker
+            if len(inter_value) != 0:
+                self.markers.set_data(pos=np.array([inter_pos[np.argmax(inter_value)]]),
+                                      face_color='yellow')
+
             self._vispy_widget.canvas.update()
 
     def on_mouse_release(self, event):
@@ -94,8 +88,7 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
         Get the mask of selected data and get them highlighted.
         :param event:
         """
-
-        # Get the visible datasets
+        # Get the visible data set
         if event.button == 1 and self.mode and self.mode is not 'point':
             visible_data, visual = self.get_visible_data()
             data = self.get_map_data()
@@ -111,7 +104,9 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             elif self.mode is 'ellipse':
                 xmin, ymin = np.min(self.line_pos[:, 0]), np.min(self.line_pos[:, 1])
                 xmax, ymax = np.max(self.line_pos[:, 0]), np.max(self.line_pos[:, 1])
-                c = CircularROI((xmax + xmin) / 2., (ymax + ymin) / 2., (xmax - xmin) / 2.)  # (xc, yc, radius)
+
+                # (xc, yc, radius)
+                c = CircularROI((xmax+xmin)/2., (ymax+ymin)/2., (xmax-xmin)/2.)
                 mask = c.contains(data[:, 0], data[:, 1])
 
             elif self.mode is 'rectangle':
@@ -160,24 +155,17 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
         :return: Start point and end point position.
         """
         visible_data, visual = self.get_visible_data()
-        tr_back = visual.get_transform(map_from='canvas', map_to='visual') # TODO: put visual to self.visual
-        print('=======================')
-        print('chain transform', tr_back)
-        print('=======================')
-
-        # try add the visual's transform
-        # tr_back = tr_back * self.visual_transform
-        print('chain transform after visual', tr_back)
-        print('=======================')
+        tr_back = visual.get_transform(map_from='canvas', map_to='visual')
 
         _cam = self._vispy_widget.view.camera
-        _cam_point = _cam.transform.map(_cam.center)  #TODO: this is not correct
+        start_point = _cam.transform.map(_cam.center)
 
-        trpos_start = np.insert(self.selection_origin, 2, 1)
-        trpos_start = tr_back.map(trpos_start)
-        trpos_start = self.visual_transform.map(trpos_start)
-        print('trpos_start after visual transform', trpos_start)
+        end_point = np.insert(self.selection_origin, 2, 1)
+        end_point = tr_back.map(end_point)
+        # add the visual local transform
+        end_point = self.visual_tr.map(end_point)
+        end_point = end_point[:3] / end_point[3]
 
-        trpos_start = trpos_start[:3] / trpos_start[3]
+        self.ray_line.set_data(np.array([end_point, start_point[:3]]))
 
-        return np.array([trpos_start, _cam_point[:3]])
+        return np.array([end_point, start_point[:3]])

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -30,6 +30,9 @@ class VispyVolumeViewer(BaseVispyViewer):
                                  "3D volume rendering viewer",
                                  buttons=QMessageBox.Ok)
 
+        # TODO: how to get text value from volume_toolbar...
+        self.show_status('hello')
+
     def add_data(self, data):
 
         if data in self._layer_artist_container:


### PR DESCRIPTION
I implement the ray cursor line into Glue 3D Viewers as shown below, using the current picking icon on the menu bar.

But due to the normalization of the volume data, the transform of those `ray markers` are not correct along the ray casting line :(  Could you help me to have a look @astrofrog ? Many thanks!

![image](https://cloud.githubusercontent.com/assets/13411839/15300948/46f4f246-1b79-11e6-88f8-eb2b6b31acfb.png)
