### PR TITLE
make selection frame wider

### DIFF
--- a/glue_vispy_viewers/common/toolbar.py
+++ b/glue_vispy_viewers/common/toolbar.py
@@ -65,7 +65,9 @@ class VispyDataViewerToolbar(QtGui.QToolBar):
 
         # Initialize drawing visual
         self.line_pos = []
-        self.line = scene.visuals.Line(color=settings.FOREGROUND_COLOR, method='gl', parent=self._vispy_widget.canvas.scene)
+        self.line = scene.visuals.Line(color=settings.FOREGROUND_COLOR,
+                                       width=2, method='agg',
+                                       parent=self._vispy_widget.canvas.scene)
 
         # Selection defaults
         self._scatter = None


### PR DESCRIPTION
Not easy to distinguish from the gridbox frame. Changed as below (maybe we should also set a different color for it like red? @astrofrog )

![image](https://cloud.githubusercontent.com/assets/13411839/15838082/42a7cb0e-2c0a-11e6-8346-6c9f030d8a9a.png)
