### PR TITLE
Improve selection performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
 - Add support for n-dimensional components in 3D scatter plot viewer. [#158]
 
+- Factor of ~10 improvement in performance when selecting data in the scatter
+  or volume viewers.
+
 0.4 (2016-05-24)
 ----------------
 

--- a/glue_vispy_viewers/scatter/scatter_toolbar.py
+++ b/glue_vispy_viewers/scatter/scatter_toolbar.py
@@ -3,6 +3,7 @@ This is for 3D selection in Glue 3d scatter plot viewer.
 """
 from ..common.toolbar import VispyDataViewerToolbar
 from glue.core.roi import RectangularROI, CircularROI
+from ..utils import as_matrix_transform
 import numpy as np
 from matplotlib import path
 
@@ -87,7 +88,7 @@ class ScatterSelectionToolbar(VispyDataViewerToolbar):
         #     for id in range(1, n):
         #         layer = visible_data[id]
         #         np.append(layer_data, np.array([layer[x_att], layer[y_att], layer[z_att]]).transpose(), axis=0)
-        tr = visual.get_transform(map_from='visual', map_to='canvas')
+        tr = as_matrix_transform(visual.get_transform(map_from='visual', map_to='canvas'))
         data = tr.map(layer_data)
         data /= data[:, 3:]  # normalize with homogeneous coordinates
         return data[:, :2]

--- a/glue_vispy_viewers/utils.py
+++ b/glue_vispy_viewers/utils.py
@@ -1,0 +1,27 @@
+from glue_vispy_viewers.extern.vispy.visuals.transforms import ChainTransform, NullTransform, MatrixTransform, STTransform
+from glue_vispy_viewers.extern.vispy.visuals.transforms.base_transform import InverseTransform
+
+
+def as_matrix_transform(transform):
+    """
+    Simplify a transform to a single matrix transform, which makes it a lot
+    faster to compute transformations.
+
+    Raises a TypeError if the transform cannot be simplified.
+    """
+    if isinstance(transform, ChainTransform):
+        matrix = MatrixTransform()
+        for tr in transform.transforms:
+            matrix = matrix * as_matrix_transform(tr)
+        return matrix
+    elif isinstance(transform, InverseTransform):
+        matrix = as_matrix_transform(transform._inverse)
+        return MatrixTransform(matrix.inv_matrix)
+    elif isinstance(transform, NullTransform):
+        return MatrixTransform()
+    elif isinstance(transform, STTransform):
+        return transform.as_matrix()
+    elif isinstance(transform, MatrixTransform):
+        return transform
+    else:
+        raise TypeError("Could not simplify transform of type {0}".format(type(transform)))


### PR DESCRIPTION
These changes improve the selection performance by a factor of ~10x for large cubes. Example timing to select using the lasso in a 3D cube with shape (193,512,512)

Before: 120 seconds
All changes except `as_matrix_transform`: 40 seconds
Including `as_matrix_transform`: 12 seconds

I want to try and make it even faster, but I can do that in a separate pull request.
