### PR TITLE
replace isosurface visual method to display

### DIFF
--- a/glue_vispy_viewers/isosurface/isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/isosurface_viewer.py
@@ -4,6 +4,9 @@ from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import IsosurfaceLayerArtist
 from .layer_style_widget import IsosurfaceLayerStyleWidget
 
+from ..common import tools  # noqa
+from ..common import selection_tools  # noqa
+
 
 class VispyIsosurfaceViewer(BaseVispyViewer):
 

--- a/glue_vispy_viewers/isosurface/layer_artist.py
+++ b/glue_vispy_viewers/isosurface/layer_artist.py
@@ -1,12 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-from matplotlib.colors import ColorConverter
 from scipy.ndimage import gaussian_filter
-
-
-from ..extern.vispy import scene
-from ..extern.vispy.color import Color
 
 from glue.core.data import Subset
 from glue.core.exceptions import IncompatibleAttribute
@@ -14,11 +9,10 @@ from glue.core.exceptions import IncompatibleAttribute
 from .layer_state import IsosurfaceLayerState
 from ..common.layer_artist import VispyLayerArtist
 
-from ..extern.vispy.color import BaseColormap, get_colormaps
-from ..extern.vispy.visuals.volume import frag_dict, FRAG_SHADER
+from ..extern.vispy.color import BaseColormap
 
-from itertools import cycle
 from .multi_iso_visual import MultiIsoVisual
+
 
 # TODO: create colormaps that is prettier
 class TransFire(BaseColormap):
@@ -57,6 +51,7 @@ class TransFire(BaseColormap):
 # vec4 translucent_fire(float t) {
 #         return vec4(pow(t, 0.5), t, t*t, max(0, t*1.05 - 0.05));
 #     }
+
 
 class IsosurfaceLayerArtist(VispyLayerArtist):
     """
@@ -179,7 +174,9 @@ class IsosurfaceLayerArtist(VispyLayerArtist):
         gaussian_data = gaussian_filter(data/4, 1)
 
         # TODO: the clim here conflict with set levels
-        # self._iso_visual.set_data(np.nan_to_num(gaussian_data), clim=(self.level_low, self.level_high))
+        # self._iso_visual.set_data(
+        # np.nan_to_num(gaussian_data),
+        # clim=(self.level_low, self.level_high))
         # self._iso_visual.step = self.step
 
         self._iso_visual.set_data(np.nan_to_num(gaussian_data))

--- a/glue_vispy_viewers/isosurface/layer_state.py
+++ b/glue_vispy_viewers/isosurface/layer_state.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
+from glue.config import colormaps
 from glue.external.echo import CallbackProperty
-from glue.core.state_objects import StateAttributeSingleValueHelper
+from glue.core.state_objects import StateAttributeLimitsHelper
 
 from ..common.layer_state import VispyLayerState
 
@@ -16,7 +16,12 @@ class IsosurfaceLayerState(VispyLayerState):
     """
 
     attribute = CallbackProperty()
-    level = CallbackProperty()
+
+    level_low = CallbackProperty()
+    level_high = CallbackProperty()
+    cmap = CallbackProperty()
+    step = CallbackProperty()
+    step_value = CallbackProperty()
 
     level_cache = CallbackProperty({})
 
@@ -24,14 +29,11 @@ class IsosurfaceLayerState(VispyLayerState):
 
         super(IsosurfaceLayerState, self).__init__(**kwargs)
 
-        def default_level(values):
-            percentile = max((1 - 1e3 / values.size) * 100, 99)
-            return np.percentile(values, percentile)
+        self.level_helper = StateAttributeLimitsHelper(self, attribute='attribute',
+                                                       lower='level_low', upper='level_high')
 
-        self.level_helper = StateAttributeSingleValueHelper(self, 'attribute',
-                                                            default_level,
-                                                            value='level',
-                                                            cache=self.level_cache)
+        if self.cmap is None:
+            self.cmap = colormaps.members[0][1]
 
     def update_priority(self, name):
         return 0 if name == 'level' else 1

--- a/glue_vispy_viewers/isosurface/layer_state.py
+++ b/glue_vispy_viewers/isosurface/layer_state.py
@@ -20,8 +20,7 @@ class IsosurfaceLayerState(VispyLayerState):
     level_low = CallbackProperty()
     level_high = CallbackProperty()
     cmap = CallbackProperty()
-    step = CallbackProperty()
-    step_value = CallbackProperty()
+    step = CallbackProperty(4)
 
     level_cache = CallbackProperty({})
 

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -24,9 +24,6 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
 
         self.state = layer_artist.state
 
-        connect_kwargs = {'value_alpha': dict(value_range=(0., 1.))}
-        autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
-
         self.layer_artist = layer_artist
         self.layer = layer_artist.layer
 
@@ -35,8 +32,9 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
         self.att_helper = ComponentIDComboHelper(self.ui.combodata_attribute, self.layer)
         self.att_helper.append_data(self.layer)
 
-        # Set up internal connections
-        self.ui.combodata_attribute.currentIndexChanged.connect(self._update_levels)
+        connect_kwargs = {'value_alpha': dict(value_range=(0., 1.)),
+                          'value_step': dict(value_range=(0, 10))}
+        autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
 
 if __name__ == "__main__":

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -33,7 +33,7 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
         self.att_helper.append_data(self.layer)
 
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.)),
-                          'value_step': dict(value_range=(0, 10))}
+                          'value_step': dict(value_range=(1, 10))}
         autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
 

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-import numpy as np
-
-from glue.core.subset import Subset
-
 from qtpy import QtWidgets
 
 from glue.utils.qt import load_ui
@@ -37,46 +33,45 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
         autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
 
-if __name__ == "__main__":
-
-    from glue.utils.qt import get_qapp
-    from glue.external.echo import CallbackProperty
-
-    app = get_qapp()
-
-    class Style(object):
-        # TODO: need a cmap here
-        cmap = CallbackProperty(get_colormap('autumn'))
-        # alpha = CallbackProperty(1.0)
-        # markersize = CallbackProperty(4)
-
-    class Component(object):
-        def __init__(self, label):
-            self.label = label
-
-    c1 = Component('a')
-    c2 = Component('b')
-    c3 = Component('c')
-
-    class Layer(object):
-        style = Style()
-        visible_components = [c1, c2, c3]
-
-    class LayerArtist(object):
-        layer = Layer()
-
-        attribute = CallbackProperty()
-        level_low = CallbackProperty()
-        level_high = CallbackProperty()
-        # We don't have IntLineProperty?
-        cmap = CallbackProperty()
-        step = CallbackProperty()
-        step_value = CallbackProperty()
-
-
-    layer_artist = LayerArtist()
-
-    widget = IsosurfaceLayerStyleWidget(layer_artist)
-    widget.show()
-
-    app.exec_()
+# if __name__ == "__main__":
+#
+#     from glue.utils.qt import get_qapp
+#     from glue.external.echo import CallbackProperty
+#
+#     app = get_qapp()
+#
+#     # class Style(object):
+#         # TODO: need a cmap here
+#         # cmap = CallbackProperty(get_colormap('autumn'))
+#         # alpha = CallbackProperty(1.0)
+#         # markersize = CallbackProperty(4)
+#
+#     class Component(object):
+#         def __init__(self, label):
+#             self.label = label
+#
+#     c1 = Component('a')
+#     c2 = Component('b')
+#     c3 = Component('c')
+#
+#     class Layer(object):
+#         style = Style()
+#         visible_components = [c1, c2, c3]
+#
+#     class LayerArtist(object):
+#         layer = Layer()
+#
+#         attribute = CallbackProperty()
+#         level_low = CallbackProperty()
+#         level_high = CallbackProperty()
+#         # We don't have IntLineProperty?
+#         cmap = CallbackProperty()
+#         step = CallbackProperty()
+#         step_value = CallbackProperty()
+#
+#     layer_artist = LayerArtist()
+#
+#     widget = IsosurfaceLayerStyleWidget(layer_artist)
+#     widget.show()
+#
+#     app.exec_()

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -38,25 +38,47 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
         # Set up internal connections
         self.ui.combodata_attribute.currentIndexChanged.connect(self._update_levels)
 
-    def _update_levels(self):
 
-        if isinstance(self.layer, Subset):
-            self.level = 0.5
-            return
+if __name__ == "__main__":
 
-        if not hasattr(self, '_levels'):
-            self._levels = {}
+    from glue.utils.qt import get_qapp
+    from glue.external.echo import CallbackProperty
 
-        if self.attribute in self._levels:
-            self.level = self._levels[self.state.attribute]
-        else:
-            self.level = self.default_levels(self.state.attribute)
-            self._levels[self.attribute] = self.level
+    app = get_qapp()
 
-    def default_levels(self, attribute):
-        # For subsets, we want to compute the levels based on the full
-        # dataset not just the subset.
-        if isinstance(self.layer, Subset):
-            return 0.5
-        else:
-            return np.nanmedian(self.layer[attribute])
+    class Style(object):
+        # TODO: need a cmap here
+        cmap = CallbackProperty(get_colormap('autumn'))
+        # alpha = CallbackProperty(1.0)
+        # markersize = CallbackProperty(4)
+
+    class Component(object):
+        def __init__(self, label):
+            self.label = label
+
+    c1 = Component('a')
+    c2 = Component('b')
+    c3 = Component('c')
+
+    class Layer(object):
+        style = Style()
+        visible_components = [c1, c2, c3]
+
+    class LayerArtist(object):
+        layer = Layer()
+
+        attribute = CallbackProperty()
+        level_low = CallbackProperty()
+        level_high = CallbackProperty()
+        # We don't have IntLineProperty?
+        cmap = CallbackProperty()
+        step = CallbackProperty()
+        step_value = CallbackProperty()
+
+
+    layer_artist = LayerArtist()
+
+    widget = IsosurfaceLayerStyleWidget(layer_artist)
+    widget.show()
+
+    app.exec_()

--- a/glue_vispy_viewers/isosurface/layer_style_widget.ui
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.ui
@@ -6,29 +6,62 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>212</width>
-    <height>83</height>
+    <width>240</width>
+    <height>118</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
    <property name="verticalSpacing">
     <number>5</number>
    </property>
+   <property name="margin">
+    <number>5</number>
+   </property>
+   <item row="2" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Limits:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="valuetext_level_low"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="valuetext_level_high">
+       <property name="text">
+        <string>2</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Color:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QColormapCombo" name="combotext_cmap"/>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QComboBox" name="combo_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -36,59 +69,45 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QColorBox" name="label_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QSlider" name="value_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combodata_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QLineEdit" name="valuetext_level"/>
+   <item row="3" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Step:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="value_step">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="singleStep">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>5</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="valuetext_step"/>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QColorBox</class>
-   <extends>QLabel</extends>
+   <class>QColormapCombo</class>
+   <extends>QComboBox</extends>
    <header>glue.utils.qt.colors</header>
   </customwidget>
  </customwidgets>

--- a/glue_vispy_viewers/isosurface/layer_style_widget.ui
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.ui
@@ -51,12 +51,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QColormapCombo" name="combotext_cmap"/>
+      <widget class="QColormapCombo" name="combodata_cmap"/>
      </item>
     </layout>
    </item>
    <item row="0" column="1" colspan="3">
-    <widget class="QComboBox" name="combo_attribute">
+    <widget class="QComboBox" name="combodata_attribute">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>

--- a/glue_vispy_viewers/isosurface/multi_iso_visual.py
+++ b/glue_vispy_viewers/isosurface/multi_iso_visual.py
@@ -1,0 +1,357 @@
+# This file implements a MultiIsoVisual class that can be used to show
+# multiple layers of isosurface simultaneously. It is derived from the original
+# VolumeVisual class in vispy.visuals.volume, which is releaed under a BSD license
+# included here:
+#
+# ===========================================================================
+# Vispy is licensed under the terms of the (new) BSD license:
+#
+# Copyright (c) 2015, authors of Vispy
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Vispy Development Team nor the names of its
+#   contributors may be used to endorse or promote products
+#   derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+# OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ===========================================================================
+#
+# This modified version is released under the BSD license given in the LICENSE
+# file in this repository.
+
+
+from ..extern.vispy.gloo import Texture3D, TextureEmulated3D, VertexBuffer, IndexBuffer
+from ..extern.vispy.visuals.volume import VolumeVisual, Visual
+from ..extern.vispy.scene.visuals import create_visual_node
+
+import numpy as np
+from ..extern.vispy.visuals.volume import VERT_SHADER, frag_dict
+from ..extern.vispy.color import get_colormap
+
+# TODO: find a way to add a uniform variable instead of rewriting the whole shader code
+
+# Fragment shader
+FRAG_SHADER = """
+// uniforms
+uniform $sampler_type u_volumetex;
+uniform vec3 u_shape;
+uniform float u_threshold;
+uniform float u_relative_step_size;
+uniform int level; //threshold level numbers
+//varyings
+// varying vec3 v_texcoord;
+varying vec3 v_position;
+varying vec4 v_nearpos;
+varying vec4 v_farpos;
+// uniforms for lighting. Hard coded until we figure out how to do lights
+const vec4 u_ambient = vec4(0.2, 0.4, 0.2, 1.0);
+const vec4 u_diffuse = vec4(0.8, 0.2, 0.2, 1.0);
+const vec4 u_specular = vec4(1.0, 1.0, 1.0, 1.0);
+const float u_shininess = 40.0;
+//varying vec3 lightDirs[1];
+// global holding view direction in local coordinates
+vec3 view_ray;
+float rand(vec2 co)
+{{
+    // Create a pseudo-random number between 0 and 1.
+    // http://stackoverflow.com/questions/4200224
+    return fract(sin(dot(co.xy ,vec2(12.9898, 78.233))) * 43758.5453);
+}}
+float colorToVal(vec4 color1)
+{{
+    return color1.g; // todo: why did I have this abstraction in visvis?
+}}
+vec4 calculateColor(vec4 betterColor, vec3 loc, vec3 step)
+{{
+    // Calculate color by incorporating lighting
+    vec4 color1;
+    vec4 color2;
+
+    // View direction
+    vec3 V = normalize(view_ray);
+
+    // calculate normal vector from gradient
+    vec3 N; // normal
+    color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(step[0],0.0,0.0) );
+    N[0] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,-step[1],0.0) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,step[1],0.0) );
+    N[1] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    color1 = $sample( u_volumetex, loc+vec3(0.0,0.0,-step[2]) );
+    color2 = $sample( u_volumetex, loc+vec3(0.0,0.0,step[2]) );
+    N[2] = colorToVal(color1) - colorToVal(color2);
+    betterColor = max(max(color1, color2),betterColor);
+    float gm = length(N); // gradient magnitude
+    N = normalize(N);
+
+    // Flip normal so it points towards viewer
+    float Nselect = float(dot(N,V) > 0.0);
+    N = (2.0*Nselect - 1.0) * N;  // ==  Nselect * N - (1.0-Nselect)*N;
+
+    // Get color of the texture (albeido)
+    color1 = betterColor;
+    color2 = color1;
+    // todo: parametrise color1_to_color2
+
+    // Init colors
+    vec4 ambient_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 diffuse_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 specular_color = vec4(0.0, 0.0, 0.0, 0.0);
+    vec4 final_color;
+
+    // todo: allow multiple light, define lights on viewvox or subscene
+    int nlights = 1;
+    for (int i=0; i<nlights; i++)
+    {{
+        // Get light direction (make sure to prevent zero devision)
+        vec3 L = normalize(view_ray);  //lightDirs[i];
+        float lightEnabled = float( length(L) > 0.0 );
+        L = normalize(L+(1.0-lightEnabled));
+
+        // Calculate lighting properties
+        float lambertTerm = clamp( dot(N,L), 0.0, 1.0 );
+        vec3 H = normalize(L+V); // Halfway vector
+        float specularTerm = pow( max(dot(H,N),0.0), u_shininess);
+
+        // Calculate mask
+        float mask1 = lightEnabled;
+
+        // Calculate colors
+        ambient_color +=  mask1 * u_ambient;  // * gl_LightSource[i].ambient;
+        diffuse_color +=  mask1 * lambertTerm;
+        specular_color += mask1 * specularTerm * u_specular;
+    }}
+
+    // Calculate final color by componing different components
+    final_color = color2 * ( ambient_color + diffuse_color) + specular_color;
+    final_color.a = color2.a;
+
+    // Done
+    return final_color;
+}}
+// for some reason, this has to be the last function in order for the
+// filters to be inserted in the correct place...
+
+void main() {{
+    vec3 farpos = v_farpos.xyz / v_farpos.w;
+    vec3 nearpos = v_nearpos.xyz / v_nearpos.w;
+    // Calculate unit vector pointing in the view direction through this
+    // fragment.
+    view_ray = normalize(farpos.xyz - nearpos.xyz);
+    // Compute the distance to the front surface or near clipping plane
+    float distance = dot(nearpos-v_position, view_ray);
+    distance = max(distance, min((-0.5 - v_position.x) / view_ray.x,
+                            (u_shape.x - 0.5 - v_position.x) / view_ray.x));
+    distance = max(distance, min((-0.5 - v_position.y) / view_ray.y,
+                            (u_shape.y - 0.5 - v_position.y) / view_ray.y));
+    distance = max(distance, min((-0.5 - v_position.z) / view_ray.z,
+                            (u_shape.z - 0.5 - v_position.z) / view_ray.z));
+    // Now we have the starting position on the front surface
+    vec3 front = v_position + view_ray * distance;
+    // Decide how many steps to take
+    int nsteps = int(-distance / u_relative_step_size + 0.5);
+    if( nsteps < 1 )
+        discard;
+    // Get starting location and step vector in texture coordinates
+    vec3 step = ((v_position - front) / u_shape) / nsteps;
+    vec3 start_loc = front / u_shape;
+    // For testing: show the number of steps. This helps to establish
+    // whether the rays are correctly oriented
+    //gl_FragColor = vec4(0.0, nsteps / 3.0 / u_shape.x, 1.0, 1.0);
+    //return;
+
+    {before_loop}
+
+    // This outer loop seems necessary on some systems for large
+    // datasets. Ugly, but it works ...
+    vec3 loc = start_loc;
+    int iter = 0;
+    while (iter < nsteps) {{
+        for (iter=iter; iter<nsteps; iter++)
+        {{
+            // Get sample color
+            vec4 color = $sample(u_volumetex, loc);
+            float val = color.g;
+
+            {in_loop}
+
+            // Advance location deeper into the volume
+            loc += step;
+        }}
+    }}
+    {after_loop}
+
+    /* Set depth value - from visvis TODO
+    int iter_depth = int(maxi);
+    // Calculate end position in world coordinates
+    vec4 position2 = vertexPosition;
+    position2.xyz += ray*shape*float(iter_depth);
+    // Project to device coordinates and set fragment depth
+    vec4 iproj = gl_ModelViewProjectionMatrix * position2;
+    iproj.z /= iproj.w;
+    gl_FragDepth = (iproj.z+1.0)/2.0;
+    */
+}}
+"""  # noqa
+
+ISO_SNIPPETS = dict(
+    before_loop="""
+        vec4 total_color = vec4(0.0);  // final color
+        vec4 src = vec4(0.0);
+        vec4 dst = vec4(0.0);
+        vec3 dstep = 1.5 / u_shape;  // step to sample derivative
+        gl_FragColor = vec4(0.0);
+        float val_prev = 0;
+        float outa = 0;
+        vec3 loc_prev = vec3(0.0);
+        vec3 loc_mid = vec3(0.0);
+
+    """,
+    in_loop="""
+        for (int i=0; i<level; i++){
+
+        // render from outside to inside
+        if (val < u_threshold*(1.0-i/float(level)) && val_prev > u_threshold*(1.0-i/float(level))){
+            // Use bisection to find correct position of contour
+            for (int i=0; i<20; i++) {
+                loc_mid = 0.5 * (loc_prev + loc);
+                val = $sample(u_volumetex, loc_mid).g;
+                if (val < u_threshold) {
+                    loc = loc_mid;
+                } else {
+                    loc_prev = loc_mid;
+                }
+            }
+
+            //dst = $cmap(val);  // this will call colormap function if have
+            dst = $cmap(i);
+            dst = calculateColor(dst, loc, dstep);
+            dst.a = 1. * (1.0 - i/float(level)); // transparency
+
+            src = total_color;
+
+            outa = src.a + dst.a * (1 - src.a);
+            total_color = (src * src.a + dst * dst.a * (1 - src.a)) / outa;
+            total_color.a = outa;
+        }
+        }
+        val_prev = val;
+        loc_prev = loc;
+        """,
+    after_loop="""
+        gl_FragColor = total_color;
+        """,
+)
+
+ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
+
+frag_dict['iso'] = ISO_FRAG_SHADER
+
+class MultiIsoVisual(VolumeVisual):
+    """
+    Carry out additive volume rendering using an RGBA cube instead of a 3d cube
+    of values and a colormap.
+    Parameters
+    ----------
+    data : np.ndarray
+        A 4-d array with dimensions (z, y, x, 4) where the last dimension
+        corresponds to RGBA. The data should be normalized from 0 to 1 in each
+        channel.
+    relative_step_size : float
+        The relative step size to step through the volume. Default 0.8.
+        Increase to e.g. 1.5 to increase performance, at the cost of
+        quality.
+    emulate_texture : bool
+        Use 2D textures to emulate a 3D texture. OpenGL ES 2.0 compatible,
+        but has lower performance on desktop platforms.
+    """
+    # TODO: add cmap later
+    def __init__(self, vol, clim=None, relative_step_size=0.8, threshold=0.8, step=4, cmap='hot',
+                 emulate_texture=False):
+        tex_cls = TextureEmulated3D if emulate_texture else Texture3D
+
+        # Storage of information of volume
+        self._vol_shape = ()
+        self._clim = None
+        self._need_vertex_update = True
+
+        # Set the colormap
+        self._cmap = get_colormap(cmap)
+        # self._cmap = TransGrays()
+
+        # Create gloo objects
+        self._vertices = VertexBuffer()
+        self._texcoord = VertexBuffer(
+            np.array([
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0, 1, 1],
+                [1, 1, 1],
+            ], dtype=np.float32))
+        self._tex = tex_cls((10, 10, 10), interpolation='linear',
+                            wrapping='clamp_to_edge')
+
+        # Create program
+        Visual.__init__(self, vcode=VERT_SHADER, fcode=FRAG_SHADER)
+        self.shared_program['u_volumetex'] = self._tex
+        self.shared_program['a_position'] = self._vertices
+        self.shared_program['a_texcoord'] = self._texcoord
+        self.shared_program['u_threshold'] = threshold
+        self.shared_program['level'] = step
+        self._draw_mode = 'triangle_strip'
+        self._index_buffer = IndexBuffer()
+
+        # Only show back faces of cuboid. This is required because if we are
+        # inside the volume, then the front faces are outside of the clipping
+        # box and will not be drawn.
+        self.set_gl_state('translucent', cull_face=False)
+
+        # Set data
+        self.set_data(vol, clim)
+
+        # Set params
+        self.method = 'iso'
+        self.relative_step_size = relative_step_size
+        self.threshold = threshold if (threshold is not None) else vol.mean()
+        self.step = step
+        self.freeze()
+
+    @property
+    def step(self):
+        return self._step
+
+    @step.setter
+    def step(self, value):
+        self._step = int(value)
+        if 'level' in self.shared_program:
+            self.unfreeze()
+            self.shared_program['level'] = self._step
+            self.freeze()
+        self.update()
+
+
+MultiIsoVisual = create_visual_node(MultiIsoVisual)

--- a/glue_vispy_viewers/isosurface/multi_iso_visual.py
+++ b/glue_vispy_viewers/isosurface/multi_iso_visual.py
@@ -267,6 +267,7 @@ ISO_FRAG_SHADER = FRAG_SHADER.format(**ISO_SNIPPETS)
 
 frag_dict['iso'] = ISO_FRAG_SHADER
 
+
 class MultiIsoVisual(VolumeVisual):
     """
     Carry out additive volume rendering using an RGBA cube instead of a 3d cube

--- a/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
@@ -59,7 +59,7 @@ def test_isosurface_viewer(tmpdir):
 
     # Get layer artist style editor
     layer_artist = volume.layers[0]
-    style_widget = volume._view.layout_style_widgets[layer_artist]
+    style_widget = volume._view.layout_style_widgets[layer_artist].state
 
     style_widget.attribute = data.id['b']
     style_widget.level_low = 0.1
@@ -67,7 +67,7 @@ def test_isosurface_viewer(tmpdir):
 
     # test set label from slider
     style_widget.step = 5
-    assert style_widget.step_value == 5.0
+    assert style_widget.step == 5.0
 
     # test edit step label text
     style_widget.ui.step_edit.setText('4')
@@ -94,7 +94,7 @@ def test_isosurface_viewer(tmpdir):
 
     assert volume_r.viewer_size == (400, 500)
 
-    options = volume_r.options_widget()
+    options = volume_r.options_widget().state
 
     assert options.x_stretch == 0.5
     assert options.y_stretch == 1.0

--- a/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
@@ -7,9 +7,7 @@ from glue.core import DataCollection, Data
 from glue.app.qt.application import GlueApplication
 from glue.core.component import Component
 
-from ...common.tests.util import simple_session
 from ..isosurface_viewer import VispyIsosurfaceViewer
-from ..multi_iso_visual import MultiIsoVisual
 
 GLUE_LT_08 = LooseVersion(glue.__version__) < LooseVersion('0.8')
 

--- a/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
@@ -1,22 +1,118 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 
-from glue.core import Data
+import glue
+from glue.core import DataCollection, Data
+from glue.app.qt.application import GlueApplication
+from glue.core.component import Component
+
 from ...common.tests.util import simple_session
-
 from ..isosurface_viewer import VispyIsosurfaceViewer
+from ..multi_iso_visual import MultiIsoVisual
+
+GLUE_LT_08 = LooseVersion(glue.__version__) < LooseVersion('0.8')
 
 
-def test_Isosurface_viewer():
+def make_test_data():
+
+    data = Data(label="Test Cube Data")
+
+    np.random.seed(12345)
+
+    for letter in 'abc':
+        comp = Component(np.random.random((10, 10, 10)))
+        data.add_component(comp, letter)
+
+    return data
+
+
+def test_isosurface_viewer(tmpdir):
 
     # Create fake data
-    data = Data(primary=np.arange(1000).reshape((10, 10, 10)))
+    data = make_test_data()
 
     # Create fake session
-    session = simple_session()
-    session.data_collection.append(data)
 
-    w = VispyIsosurfaceViewer(session)
-    w.add_data(data)
-    w.show()
+    dc = DataCollection([data])
+    ga = GlueApplication(dc)
+    ga.show()
 
-    # TODO: add tests for visual options
+    volume = ga.new_data_viewer(VispyIsosurfaceViewer)
+    volume.add_data(data)
+    volume.viewer_size = (400, 500)
+
+    options = volume.options_widget()
+
+    options.x_stretch = 0.5
+    options.y_stretch = 1.0
+    options.z_stretch = 2.0
+
+    options.x_min = -0.1
+    options.x_max = 10.1
+    options.y_min = 0.1
+    options.y_max = 10.9
+    options.z_min = 0.2
+    options.z_max = 10.8
+
+    options.visible_box = False
+
+    # Get layer artist style editor
+    layer_artist = volume.layers[0]
+    style_widget = volume._view.layout_style_widgets[layer_artist]
+
+    style_widget.attribute = data.id['b']
+    style_widget.level_low = 0.1
+    style_widget.level_high = 0.9
+
+    # test set label from slider
+    style_widget.step = 5
+    assert style_widget.step_value == 5.0
+
+    # test edit step label text
+    style_widget.ui.step_edit.setText('4')
+    style_widget.ui.step_edit.editingFinished.emit()
+    assert style_widget.step == 4
+
+    # Check that writing a session works as expected.
+
+    session_file = tmpdir.join('test_volume_viewer.glu').strpath
+    ga.save_session(session_file)
+    ga.close()
+
+    # test MultiIsoVisual
+    visual = layer_artist._iso_visual
+    assert isinstance(visual, MultiIsoVisual)
+    assert visual.step == style_widget.step
+    # assert visual.threshold == style_widget.level_high  # default
+
+    # Now we can check that everything is restored correctly
+    ga2 = GlueApplication.restore_session(session_file)
+    ga2.show()
+
+    volume_r = ga2.viewers[0][0]
+
+    assert volume_r.viewer_size == (400, 500)
+
+    options = volume_r.options_widget()
+
+    assert options.x_stretch == 0.5
+    assert options.y_stretch == 1.0
+    assert options.z_stretch == 2.0
+
+    assert options.x_min == -0.1
+    assert options.x_max == 10.1
+    assert options.y_min == 0.1
+    assert options.y_max == 10.9
+    assert options.z_min == 0.2
+    assert options.z_max == 10.8
+
+    assert not options.visible_box
+
+    # layer_artist = volume_r.layers[0]
+    assert style_widget.attribute.label == 'b'
+    assert style_widget.level_low == 0.1
+    assert style_widget.level_high == 0.9
+    assert style_widget.step == 4
+
+    ga2.close()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ entry_points = """
 [glue.plugins]
 vispy_volume=glue_vispy_viewers.volume:setup
 vispy_scatter=glue_vispy_viewers.scatter:setup
-vispy_isosurface=glue_vispy_viewers.isosurface:setup
+#vispy_isosurface=glue_vispy_viewers.isosurface:setup
 """
 
 with open('glue_vispy_viewers/version.py') as infile:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ entry_points = """
 [glue.plugins]
 vispy_volume=glue_vispy_viewers.volume:setup
 vispy_scatter=glue_vispy_viewers.scatter:setup
-#vispy_isosurface=glue_vispy_viewers.isosurface:setup
+vispy_isosurface=glue_vispy_viewers.isosurface:setup
 """
 
 with open('glue_vispy_viewers/version.py') as infile:


### PR DESCRIPTION
This PR replace our Isosurface viewer from using `IsoSurface` visual as shown:
![image](https://cloud.githubusercontent.com/assets/13411839/16542933/c920b404-408a-11e6-91d0-02d21b589f5a.png)

to use `Volume` visual (rendering method='iso') and gaussian smooth from the [script](https://gist.github.com/astrofrog/c097377f665967289caf) 
![image](https://cloud.githubusercontent.com/assets/13411839/16542940/110934b2-408b-11e6-8665-16f6753b6a5d.png)

@astrofrog Do you know why the transparency doesn't work now? As the outer Isosurface has alpha=0.5 but it's shown as opaque here?
