### PR TITLE
Add markers to 3D volume (markers pos manually input)

### DIFF
--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -54,25 +54,24 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
             self.visual_tr = self._vispy_widget.limit_transforms[self.visual]
 
         if self.mode is 'point':
-            # temperarily add 3d markers here
-            index_data = []  # wiil replace data
+            # temporary add 3d markers here
+            # TODO: add an icon for controlling
+            index_data = []
             # so in cube data the coords is in [m/s, deg, deg]
             # while our point data match the cube unit
-
+            # TODO: move catalogue data to setting file as an variable
             data = [[23.372, -0.524, 63300], [23.434, -0.522, 63300], [23.48, -0.536, 63300]] # lbv
             for each_point in data:
                 vol_index = []
-                for i in [0, 1, 2]: # TODO: make sure order of axis and order of lbv input
+                for i in [0, 1, 2]:
                     if type(self.visible_data[0].coords) != Coordinates:
-                        world = self.visible_data[0].coords.world_axis(self.visible_data[0], 2-i) # reture wcs of i'th axis
-                        value = np.argmin(np.abs(world - each_point[i]))  # return i'th index of closest point's i axis
-                        print('value', value)  #output should be one value
-                        vol_index.append(value)   # return index of volume
-                        print('vol_index', vol_index)  # return one index of volume
+                        world = self.visible_data[0].coords.world_axis(self.visible_data[0], 2-i)
+                        value = np.argmin(np.abs(world - each_point[i]))
+                        vol_index.append(value)   # index of each_point within volume array
                     else:
                         vol_index = None
                 index_data.append(vol_index)
-                print('index_data', index_data)  #should output index of lbv of first point
+
             # for each lbv do -> l*scale[0] + trans[0] as below
             trans = self.visual_tr.translate
             scale = self.visual_tr.scale
@@ -82,13 +81,10 @@ class VolumeSelectionToolbar(VispyDataViewerToolbar):
                 b = each_point[1]*scale[1] + trans[1]
                 v = each_point[2]*scale[2] + trans[2]
                 coor_data.append([l, b, v])
-            coor_data = np.array(coor_data)
-            print('coor_data', coor_data)
+            coor_data = np.array(coor_data)  # normalized coor pos
 
             self.catalogue.set_data(pos=coor_data, face_color='red')
 
-
-            #=============
             # get start and end point of ray line
             pos = self.get_ray_line()
             max_value_pos, max_value = self.get_inter_value(pos)


### PR DESCRIPTION
So this PR provides the coordinate 'match' from catalogue's WCS coor to 3D volume's normalized canvas coor, now the markers pos is manually set as an variable and get loaded, but when we figure out the data loading type 'cognition' then this code could be used.
