### PR TITLE
Fix bug that caused alpha to not work properly in scatter viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 0.5 (unreleased)
 ----------------
 
+- Fixed a bug that caused alpha scaling to not work correctly when mapping
+  scatter marker colors to an attribute. [#201]
+
 - Watch for ``NumericalDataChangedMessage`` messages. [#183, #184]
 
 - Fixed a bug that caused color-coding and size-scaling of points in 3D viewer

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -115,7 +115,7 @@ class MultiColorScatter(scene.visuals.Markers):
                     rgba = np.hstack([layer['color'], 1])
                     rgba = np.repeat(rgba, n_points).reshape(4, -1).transpose()
                 else:
-                    rgba = layer['color']
+                    rgba = layer['color'].copy()
 
                 rgba[:, 3] *= layer['alpha']
 


### PR DESCRIPTION
Specifically when mapping color to an attribute
