### PR TITLE
Implement optional clipping of data outside the view limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 - Fix Qt imports to use QtPy for new versions of glue. [#173, #186]
 
+- Add an option to clip any data outside the specified limits. [#203]
+
 0.4 (2016-05-24)
 ----------------
 

--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -35,6 +35,7 @@ class VispyOptionsWidget(QtWidgets.QWidget):
 
     visible_box = ButtonProperty('ui.checkbox_axes')
     perspective_view = ButtonProperty('ui.checkbox_perspective')
+    clip_data = ButtonProperty('ui.checkbox_clip')
 
     def __init__(self, parent=None, vispy_widget=None, data_viewer=None):
 
@@ -66,6 +67,7 @@ class VispyOptionsWidget(QtWidgets.QWidget):
 
         connect_bool_button(self._vispy_widget, 'visible_axes', self.ui.checkbox_axes)
         connect_bool_button(self._vispy_widget, 'perspective_view', self.ui.checkbox_perspective)
+        connect_bool_button(self._vispy_widget, 'clip_data', self.ui.checkbox_clip)
 
         if self._data_viewer is not None:
             self.ui.combo_x_attribute.currentIndexChanged.connect(self._data_viewer._update_attributes)

--- a/glue_vispy_viewers/common/viewer_options.ui
+++ b/glue_vispy_viewers/common/viewer_options.ui
@@ -6,61 +6,73 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>254</width>
-    <height>279</height>
+    <width>197</width>
+    <height>309</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>3D_Volume</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="2" column="5">
-    <widget class="QLineEdit" name="value_x_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   <property name="margin">
+    <number>5</number>
+   </property>
+   <item row="9" column="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>stretch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="2" colspan="4">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkbox_clip">
+       <property name="text">
+        <string>Show only data inside limits</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="checkbox_axes">
+       <property name="text">
+        <string>Show axes</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkbox_perspective">
+       <property name="text">
+        <string>Perspective</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>y axis</string>
      </property>
     </widget>
    </item>
    <item row="8" column="3">
     <widget class="QLineEdit" name="value_z_min"/>
-   </item>
-   <item row="6" column="3" colspan="2">
-    <widget class="QSlider" name="slider_y_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_z_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-     </property>
-    </widget>
    </item>
    <item row="6" column="2">
     <widget class="QLabel" name="label">
@@ -69,41 +81,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
-    <widget class="QToolButton" name="button_flip_x">
-     <property name="font">
-      <font>
-       <pointsize>14</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="3" colspan="2">
-    <widget class="QSlider" name="slider_z_stretch">
-     <property name="minimum">
-      <number>-10000</number>
-     </property>
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="singleStep">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_x_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>
     </widget>
    </item>
@@ -123,41 +104,53 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="x_lab">
+   <item row="1" column="4">
+    <widget class="QToolButton" name="button_flip_x">
      <property name="font">
       <font>
-       <weight>75</weight>
-       <bold>true</bold>
+       <pointsize>14</pointsize>
       </font>
      </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
      <property name="text">
-      <string>y axis</string>
+      <string>⇄</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_x_attribute">
+   <item row="9" column="3" colspan="2">
+    <widget class="QSlider" name="slider_z_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_y_attribute">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="x_lab">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
+   <item row="1" column="5">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>z axis</string>
+      <string>stretch:</string>
      </property>
     </widget>
-   </item>
-   <item row="5" column="3">
-    <widget class="QLineEdit" name="value_y_min"/>
    </item>
    <item row="6" column="5">
     <widget class="QLineEdit" name="value_y_stretch">
@@ -165,6 +158,19 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="value_y_min"/>
+   </item>
+   <item row="9" column="5">
+    <widget class="QLineEdit" name="value_z_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="value_x_min"/>
    </item>
    <item row="8" column="4">
     <widget class="QToolButton" name="button_flip_z">
@@ -181,6 +187,26 @@
      </property>
     </widget>
    </item>
+   <item row="8" column="5">
+    <widget class="QLineEdit" name="value_z_max"/>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="5">
+    <widget class="QLineEdit" name="value_x_stretch">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="5">
+    <widget class="QLineEdit" name="value_y_max"/>
+   </item>
    <item row="1" column="2">
     <widget class="QLabel" name="label_2">
      <property name="text">
@@ -188,11 +214,34 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="5">
-    <widget class="QLineEdit" name="value_z_max"/>
+   <item row="6" column="3" colspan="2">
+    <widget class="QSlider" name="slider_y_stretch">
+     <property name="minimum">
+      <number>-10000</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
-   <item row="5" column="5">
-    <widget class="QLineEdit" name="value_y_max"/>
+   <item row="7" column="2">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>z axis</string>
+     </property>
+    </widget>
    </item>
    <item row="8" column="2">
     <widget class="QLabel" name="label_2">
@@ -201,11 +250,8 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="5">
-    <widget class="QLineEdit" name="value_x_max"/>
-   </item>
-   <item row="4" column="3" colspan="3">
-    <widget class="QComboBox" name="combo_y_attribute">
+   <item row="7" column="3" colspan="3">
+    <widget class="QComboBox" name="combo_z_attribute">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>
@@ -239,55 +285,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>min/max:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="value_x_min"/>
-   </item>
-   <item row="9" column="5">
-    <widget class="QLineEdit" name="value_z_stretch">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>stretch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="checkbox_perspective">
-       <property name="text">
-        <string>Perspective view</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkbox_axes">
-       <property name="text">
-        <string>Coordinate axes</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="11" column="2">
+   <item row="12" column="2" colspan="4">
     <widget class="QPushButton" name="reset_button">
      <property name="text">
       <string>Reset View</string>

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -5,6 +5,8 @@ except ImportError:
 
 from glue.core import message as msg
 from glue.core import Data
+from glue.external.echo import add_callback
+from glue.utils import nonpartial
 
 try:
     from glue.external.qt import QtGui as QtWidgets
@@ -30,6 +32,9 @@ class BaseVispyViewer(DataViewer):
 
         toolbar = self._toolbar_cls(vispy_widget=self._vispy_widget, parent=self)
         self.addToolBar(toolbar)
+
+        add_callback(self._vispy_widget, 'clip_data', nonpartial(self._toggle_clip))
+        add_callback(self._vispy_widget, 'clip_limits', nonpartial(self._toggle_clip))
 
         self.status_label = None
         self.client = None
@@ -181,3 +186,10 @@ class BaseVispyViewer(DataViewer):
 
     def restore_layers(self, layers, context):
         pass
+
+    def _toggle_clip(self):
+        for layer_artist in self._layer_artist_container:
+            if self._vispy_widget.clip_data:
+                layer_artist.set_clip(self._vispy_widget.clip_limits)
+            else:
+                layer_artist.set_clip(None)

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -26,6 +26,8 @@ class VispyWidget(QtWidgets.QWidget):
 
     visible_axes = CallbackProperty()
     perspective_view = CallbackProperty()
+    clip_data = CallbackProperty()
+    clip_limits = CallbackProperty()
 
     def _update_appearance_from_settings(self):
         self.canvas.bgcolor = rgb(settings.BACKGROUND_COLOR)
@@ -141,6 +143,10 @@ class VispyWidget(QtWidgets.QWidget):
         self.axis.xlim = self.options.x_min, self.options.x_max
         self.axis.ylim = self.options.y_min, self.options.y_max
         self.axis.zlim = self.options.z_min, self.options.z_max
+
+        self.clip_limits = (self.options.x_min, self.options.x_max,
+                            self.options.y_min, self.options.y_max,
+                            self.options.z_min, self.options.z_max)
 
     def _reset_view(self):
         self.view.camera.reset()

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -92,6 +92,9 @@ class ScatterLayerArtist(LayerArtistBase):
         self._color_data = None
         self._size_data = None
 
+        self._clip_limits = None
+
+
     @property
     def visual(self):
         return self._multiscat
@@ -184,6 +187,11 @@ class ScatterLayerArtist(LayerArtistBase):
         else:
             self._enabled = True
 
+        if self._clip_limits is not None:
+            xmin, xmax, ymin, ymax, zmin, zmax = self._clip_limits
+            keep = (x >= xmin) & (x <= xmax) & (y >= ymin) & (y <= ymax) & (z >= zmin) & (z <= zmax)
+            x, y, z = x[keep], y[keep], z[keep]
+
         self._marker_data = np.array([x, y, z]).transpose()
 
         # We need to make sure we update the sizes and colors in case
@@ -224,3 +232,7 @@ class ScatterLayerArtist(LayerArtistBase):
 
         for attr in sorted(kwargs, key=priorities):
             setattr(self, attr, kwargs[attr])
+
+    def set_clip(self, limits):
+        self._clip_limits = limits
+        self._update_data()

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -45,18 +45,6 @@ class VispyScatterViewer(BaseVispyViewer):
     def _add_subset(self, message):
         self.add_subset(message.subset)
 
-    def _update_attributes(self, index=None, layer_artist=None):
-
-        if layer_artist is None:
-            layer_artists = self._layer_artist_container
-        else:
-            layer_artists = [layer_artist]
-
-        for artist in layer_artists:
-            artist.set_coordinates(self._options_widget.x_att,
-                                   self._options_widget.y_att,
-                                   self._options_widget.z_att)
-
     @classmethod
     def __setgluestate__(cls, rec, context):
         viewer = super(VispyScatterViewer, cls).__setgluestate__(rec, context)

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -75,6 +75,8 @@ class VolumeLayerArtist(LayerArtistBase):
         if isinstance(self.layer, Subset):
             add_callback(self, 'subset_mode', nonpartial(self._update_data))
 
+        self._clip_limits = None
+
     @property
     def visual(self):
         return self._multivol
@@ -157,6 +159,20 @@ class VolumeLayerArtist(LayerArtistBase):
 
             data = self.layer[self.attribute]
 
+        if self._clip_limits is not None:
+            xmin, xmax, ymin, ymax, zmin, zmax = self._clip_limits
+            imin, imax = int(np.ceil(xmin)), int(np.ceil(xmax))
+            jmin, jmax = int(np.ceil(ymin)), int(np.ceil(ymax))
+            kmin, kmax = int(np.ceil(zmin)), int(np.ceil(zmax))
+            invalid = -np.inf
+            data = data.copy()
+            data[:, :, :imin] = invalid
+            data[:, :, imax:] = invalid
+            data[:, :jmin] = invalid
+            data[:, jmax:] = invalid
+            data[:kmin] = invalid
+            data[kmax:] = invalid
+
         self._multivol.set_data(self.id, data)
         self.redraw()
 
@@ -185,3 +201,7 @@ class VolumeLayerArtist(LayerArtistBase):
 
         for attr in sorted(kwargs, key=priorities):
             setattr(self, attr, kwargs[attr])
+
+    def set_clip(self, limits):
+        self._clip_limits = limits
+        self._update_data()


### PR DESCRIPTION
Closes https://github.com/glue-viz/glue-vispy-viewers/issues/118 and #175. We also need to make sure that hidden data is not included in selections, but I'll open another issue for that since I'd like to wait until the toolbar stuff is refactored.
