### PR TITLE
Fix loading session contains both scatter and volume visual

### DIFF
--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -180,6 +180,8 @@ class ScatterLayerArtist(LayerArtistBase):
             x = self.layer[self._x_coord].ravel()
             y = self.layer[self._y_coord].ravel()
             z = self.layer[self._z_coord].ravel()
+        except AttributeError:
+            return
         except (IncompatibleAttribute, IndexError):
             # The following includes a call to self.clear()
             self.disable_invalid_attributes(self._x_coord, self._y_coord, self._z_coord)


### PR DESCRIPTION
> Traceback (most recent call last):
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/common/viewer_options.py", line 264, in _update_limits
>     self._update_aspect()
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/common/viewer_options.py", line 115, in _update_aspect
>     self._vispy_widget._update_limits()
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/common/vispy_widget.py", line 146, in _update_limits
>     self.options.z_min, self.options.z_max)
>   File "/Users/penny/anaconda/lib/python2.7/site-packages/glueviz-0.10.0.dev3145-py2.7.egg/glue/external/echo.py", line 72, in __set__
>     self.notify(instance, old, new)
>   File "/Users/penny/anaconda/lib/python2.7/site-packages/glueviz-0.10.0.dev3145-py2.7.egg/glue/external/echo.py", line 104, in notify
>     cback(new)
>   File "/Users/penny/anaconda/lib/python2.7/site-packages/glueviz-0.10.0.dev3145-py2.7.egg/glue/utils/misc.py", line 57, in result
>     return func(_args, *_kwargs)
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/common/vispy_data_viewer.py", line 192, in _toggle_clip
>     layer_artist.set_clip(None)
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/scatter/layer_artist.py", line 238, in set_clip
>     self._update_data()
>   File "/Users/penny/Works/Gluedev/glue-3d-viewer/glue_vispy_viewers/scatter/layer_artist.py", line 185, in _update_data
>     self.disable_invalid_attributes(self._x_coord, self._y_coord, self._z_coord)
> AttributeError: 'ScatterLayerArtist' object has no attribute '_x_coord'

The Scatterplots viewer does not load, so there is no x_coord attribute.
