### PR TITLE
Fix rendering with Qt5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,15 @@
-0.5.1 (2016-10-28)
-------------------
+0.6 (2016-11-03)
+----------------
 
 - Fixed a bug that caused subsets to not be added to viewers when adding a
-  dataset with already existing subsets.
+  dataset with already existing subsets. [#218]
+
+- Fixed compatibility with Qt5. [#212]
+
+- Fixed a bug that caused session files created previously to not be 
+  openable. [#213, #214]
+
+- Fixed a bug that caused 3D selections to not work properly. [#219]
 
 0.5 (2016-10-10)
 ----------------

--- a/glue_vispy_viewers/common/axes.py
+++ b/glue_vispy_viewers/common/axes.py
@@ -55,6 +55,34 @@ class AxesVisual3D(object):
         self.zax.transform = ChainTransform(transform, self.ztr)
 
     @property
+    def tick_color(self):
+        return self.xax.tick_color
+
+    @tick_color.setter
+    def tick_color(self, value):
+        self.xax.tick_color = value
+        self.yax.tick_color = value
+        self.zax.tick_color = value
+
+    @property
+    def label_color(self):
+        return self._label_color
+
+    @label_color.setter
+    def label_color(self, value):
+        self.xax.label_color = value
+        self.yax.label_color = value
+        self.zax.label_color = value
+
+    @property
+    def axis_color(self):
+        return self._axis_color
+
+    @axis_color.setter
+    def axis_color(self, value):
+        self.axis.color = value
+
+    @property
     def tick_font_size(self):
         return self.xax.tick_font_size
 

--- a/glue_vispy_viewers/common/vispy_widget.py
+++ b/glue_vispy_viewers/common/vispy_widget.py
@@ -28,7 +28,9 @@ class VispyWidgetHelper(object):
 
     def _update_appearance_from_settings(self):
         self.canvas.bgcolor = rgb(settings.BACKGROUND_COLOR)
-        self.axis.color = rgb(settings.FOREGROUND_COLOR)
+        self.axis.axis_color = rgb(settings.FOREGROUND_COLOR)
+        self.axis.tick_color = rgb(settings.FOREGROUND_COLOR)
+        self.axis.label_color = rgb(settings.FOREGROUND_COLOR)
 
     def __init__(self, parent=None):
 

--- a/glue_vispy_viewers/extern/vispy/visuals/axis.py
+++ b/glue_vispy_viewers/extern/vispy/visuals/axis.py
@@ -104,8 +104,6 @@ class AxisVisual(CompoundVisual):
         self.tick_direction = np.array(tick_direction, float)
         self.tick_direction = self.tick_direction
         self.scale_type = scale_type
-        self.axis_color = axis_color
-        self.tick_color = tick_color
 
         self.minor_tick_length = minor_tick_length  # px
         self.major_tick_length = major_tick_length  # px
@@ -116,8 +114,10 @@ class AxisVisual(CompoundVisual):
 
         self._need_update = True
 
-        self._line = LineVisual(method='gl', width=axis_width, antialias=True)
-        self._ticks = LineVisual(method='gl', width=tick_width, connect='segments', antialias=True)
+        self._line = LineVisual(method='gl', width=axis_width, antialias=True,
+                                color=axis_color)
+        self._ticks = LineVisual(method='gl', width=tick_width, connect='segments',
+                                 antialias=True, color=tick_color)
         visuals = [self._line, self._ticks]
 
         # FIXME: on Windows, the presence of TextVisual objects causes
@@ -142,6 +142,31 @@ class AxisVisual(CompoundVisual):
         if pos is not None:
             self.pos = pos
         self.domain = domain
+
+    @property
+    def label_color(self):
+        return self._text.color
+
+    @label_color.setter
+    def label_color(self, value):
+        self._text.color = value
+        self._axis_label.color = value
+
+    @property
+    def axis_color(self):
+        return self._line.color
+
+    @axis_color.setter
+    def axis_color(self, value):
+        self._line.set_data(color=value)
+
+    @property
+    def tick_color(self):
+        return self._ticks.color
+
+    @tick_color.setter
+    def tick_color(self, value):
+        self._ticks.set_data(color=value)
 
     @property
     def tick_font_size(self):

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -10,6 +10,7 @@ from glue.external.echo import CallbackProperty, add_callback
 from glue.core.data import Subset
 from glue.core.layer_artist import LayerArtistBase
 from glue.utils import nonpartial
+from glue.config import settings
 from glue.core.exceptions import IncompatibleAttribute
 from .volume_visual import MultiVolume
 from .colors import get_translucent_cmap
@@ -56,7 +57,8 @@ class VolumeLayerArtist(LayerArtistBase):
             emulate_texture = (sys.platform == 'win32' and
                                sys.version_info[0] < 3)
 
-            multivol = MultiVolume(threshold=0.1, emulate_texture=emulate_texture)
+            multivol = MultiVolume(threshold=0.1, emulate_texture=emulate_texture,
+                                   bgcolor=settings.BACKGROUND_COLOR)
 
             self.vispy_widget.add_data_visual(multivol)
             self.vispy_widget._multivol = multivol

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -50,6 +50,7 @@ FRAG_SHADER = """
 uniform vec3 u_shape;
 uniform float u_threshold;
 uniform float u_relative_step_size;
+uniform vec4 u_bgcolor;
 
 //varyings
 // varying vec3 v_texcoord;
@@ -133,8 +134,25 @@ void main() {{
 
     {after_loop}
 
-    total_color /= count;
-    total_color.a = max_alpha;
+    if(count > 0) {{
+
+        total_color /= count;
+        total_color.a = max_alpha;
+
+        // Due to issues with transparency in Qt5, we need to convert the color
+        // to a flattened version without transparency, so we do alpha blending
+        // with the background and set alpha to 1:
+        total_color.r = total_color.r * total_color.a + u_bgcolor.r * (1 - total_color.a);
+        total_color.g = total_color.g * total_color.a + u_bgcolor.g * (1 - total_color.a);
+        total_color.b = total_color.b * total_color.a + u_bgcolor.b * (1 - total_color.a);
+        total_color.a = 1.;
+
+    }} else {{
+
+        total_color = u_bgcolor;
+
+    }}
+
     gl_FragColor = total_color;
 
     /* Set depth value - from visvis TODO

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -1,4 +1,6 @@
 from glue.core.state import lookup_class_with_patches
+from glue.config import settings
+from glue.core import message as msg
 
 from qtpy.QtWidgets import QMessageBox
 
@@ -127,3 +129,8 @@ class VispyVolumeViewer(BaseVispyViewer):
                 self._options_widget.set_limits(*layer_artist.bbox)
             self._layer_artist_container.append(layer_artist)
             layer_artist.set(**props)
+
+    def _update_appearance_from_settings(self, message):
+        super(VispyVolumeViewer, self)._update_appearance_from_settings(message)
+        if hasattr(self._vispy_widget, '_multivol'):
+            self._vispy_widget._multivol.set_background(settings.BACKGROUND_COLOR)

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -41,7 +41,7 @@ from glue.external import six
 from ..extern.vispy.gloo import Texture3D, TextureEmulated3D, VertexBuffer, IndexBuffer
 from ..extern.vispy.visuals import VolumeVisual, Visual
 from ..extern.vispy.visuals.shaders import Function
-from ..extern.vispy.color import get_colormap
+from ..extern.vispy.color import get_colormap, Color
 from ..extern.vispy.scene.visuals import create_visual_node
 
 from .backports import block_reduce
@@ -74,7 +74,7 @@ class MultiVolumeVisual(VolumeVisual):
     """
 
     def __init__(self, n_volume_max=10, threshold=None, relative_step_size=0.8,
-                 emulate_texture=False):
+                 emulate_texture=False, bgcolor='white'):
 
         # Choose texture class
         tex_cls = TextureEmulated3D if emulate_texture else Texture3D
@@ -123,11 +123,14 @@ class MultiVolumeVisual(VolumeVisual):
         self.shared_program['a_position'] = self._vertices
         self.shared_program['a_texcoord'] = self._texcoord
         self.shared_program['u_shape'] = self._vol_shape[::-1]
+
         self._draw_mode = 'triangle_strip'
         self._index_buffer = IndexBuffer()
 
         self.shared_program.frag['sampler_type'] = self.textures[0].glsl_sampler_type
         self.shared_program.frag['sample'] = self.textures[0].glsl_sample
+
+        self.set_background(bgcolor)
 
         # Only show back faces of cuboid. This is required because if we are
         # inside the volume, then the front faces are outside of the clipping
@@ -145,6 +148,9 @@ class MultiVolumeVisual(VolumeVisual):
             self.freeze()
         except AttributeError:  # Older versions of VisPy
             pass
+
+    def set_background(self, color):
+        self.shared_program['u_bgcolor'] = Color(color).rgba
 
     @property
     def _free_slot_index(self):


### PR DESCRIPTION
The main issue is that in Qt5, it seems like having transparency causes issues, so we need to make sure we always blend the final colors of visuals (in particular the volumevisual) with the background color for the viewer. This is still an issue for the scatter markers, but somewhat less obvious - I will try and fix those too, but if I don't get it done in time I still want to get this fix in so as to release 0.6 ASAP.