### PR TITLE
Added __future__ imports to enforce Python 3-style division on Python 2

### DIFF
--- a/glue_vispy_viewers/common/axes.py
+++ b/glue_vispy_viewers/common/axes.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..extern.vispy import scene
 from ..extern.vispy.geometry import create_cube
 from ..extern.vispy.visuals.transforms import STTransform, ChainTransform

--- a/glue_vispy_viewers/common/selection_tools.py
+++ b/glue_vispy_viewers/common/selection_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 """
 This is for 3D selection in Glue 3d scatter plot viewer.
 """

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 try:
     from glue.viewers.common.qt.data_viewer import DataViewer
 except ImportError:

--- a/glue_vispy_viewers/isosurface/isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/isosurface_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..common.vispy_data_viewer import BaseVispyViewer
 from .layer_artist import IsosurfaceLayerArtist
 from .layer_style_widget import IsosurfaceLayerStyleWidget

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from contextlib import contextmanager
 
 import numpy as np

--- a/glue_vispy_viewers/scatter/scatter_toolbar.py
+++ b/glue_vispy_viewers/scatter/scatter_toolbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 """
 This is for 3D selection in Glue 3d scatter plot viewer.
 """

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from glue.core.state import lookup_class_with_patches
 
 from ..common.vispy_data_viewer import BaseVispyViewer

--- a/glue_vispy_viewers/utils.py
+++ b/glue_vispy_viewers/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from glue_vispy_viewers.extern.vispy.visuals.transforms import (ChainTransform, NullTransform,
                                                                 MatrixTransform, STTransform)
 from glue_vispy_viewers.extern.vispy.visuals.transforms.base_transform import InverseTransform

--- a/glue_vispy_viewers/volume/backports.py
+++ b/glue_vispy_viewers/volume/backports.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..extern.vispy.color import BaseColormap
 
 

--- a/glue_vispy_viewers/volume/floodfill_scipy.py
+++ b/glue_vispy_viewers/volume/floodfill_scipy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from scipy.ndimage.measurements import label
 
 

--- a/glue_vispy_viewers/volume/shaders.py
+++ b/glue_vispy_viewers/volume/shaders.py
@@ -35,6 +35,8 @@
 # This modified version is released under the BSD license given in the LICENSE
 # file in this repository.
 
+from __future__ import absolute_import, division, print_function
+
 try:
     from textwrap import indent
 except ImportError:  # Python < 3.5

--- a/glue_vispy_viewers/volume/volume_toolbar.py
+++ b/glue_vispy_viewers/volume/volume_toolbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 """
 This is for 3D selection in Glue 3d volume rendering viewer, with shape selection and advanced
 selection (not available now).

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from glue.core.state import lookup_class_with_patches
 from glue.config import settings
 from glue.core import message as msg

--- a/glue_vispy_viewers/volume/volume_visual.py
+++ b/glue_vispy_viewers/volume/volume_visual.py
@@ -36,6 +36,8 @@
 # This modified version is released under the BSD license given in the LICENSE
 # file in this repository.
 
+from __future__ import absolute_import, division, print_function
+
 from glue.external import six
 
 from ..extern.vispy.gloo import Texture3D, TextureEmulated3D, VertexBuffer, IndexBuffer


### PR DESCRIPTION
This fixes a bug using the volume rendering for large cubes.