### PR TITLE
Fix flipping of limits for size and cmap in 3D scatter viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 - Fixed bug with volume rendering on Windows with Python 2.7, due to
   Numpy .shape returning long integers. [#245]
 
+- Fixed bug that caused the flipping of size and cmap limits in the
+  3D viewers to not work properly. [#251]
+
 0.7.1 (unreleased)
 ------------------
 

--- a/glue_vispy_viewers/scatter/layer_state.py
+++ b/glue_vispy_viewers/scatter/layer_state.py
@@ -71,3 +71,9 @@ class ScatterLayerState(VispyLayerState):
         if self.layer is not None:
             self.size = self.layer.style.markersize
             self._sync_color = keep_in_sync(self, 'size', self.layer.style, 'markersize')
+
+    def flip_size(self):
+        self.size_att_helper.flip_limits()
+
+    def flip_cmap(self):
+        self.cmap_att_helper.flip_limits()


### PR DESCRIPTION
Fixes #248 