### PR TITLE
Add record tool to toolbar at class definition time not during __init__

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 0.7.2 (unreleased)
 ------------------
 
+- Fixed bug that caused record icon to appear multiple times when
+  successively creating 3D viewers. [#252]
+
 - Fixed bug with volume rendering on Windows with Python 2.7, due to
   Numpy .shape returning long integers. [#245]
 

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -32,7 +32,16 @@ BROKEN_CONDA_PYQT5_MESSAGE = "The conda version of PyQt5 on Linux does not inclu
 class BaseVispyViewer(DataViewer):
 
     _toolbar_cls = VispyViewerToolbar
+
     tools = ['vispy:save', 'vispy:rotate']
+
+    # If imageio is available, we can add the record icon
+    try:
+        import imageio  # noqa
+    except ImportError:
+        pass
+    else:
+        tools.insert(1, 'vispy:record')
 
     def __init__(self, session, viewer_state=None, parent=None):
 
@@ -53,14 +62,6 @@ class BaseVispyViewer(DataViewer):
 
         self.status_label = None
         self.client = None
-
-        # If imageio is available, we can add the record icon
-        try:
-            import imageio  # noqa
-        except ImportError:
-            pass
-        else:
-            self.tools.insert(1, 'vispy:record')
 
     def register_to_hub(self, hub):
 


### PR DESCRIPTION
... to avoid adding the tool multiple times to the class attribute 'tools'. Fixes #250.