### PR TITLE
Remove layer state when removing layer artist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 0.7.2 (unreleased)
 ------------------
 
+- Fixed bug that caused session files saved after removing subsets
+  to no longer be loadable. [#253]
+
 - Fixed bug that caused record icon to appear multiple times when
   successively creating 3D viewers. [#252]
 

--- a/glue_vispy_viewers/common/selection_tools.py
+++ b/glue_vispy_viewers/common/selection_tools.py
@@ -58,7 +58,8 @@ class VispyMouseMode(CheckableTool):
     def mark_selected_dict(self, indices_dict):
         subset_state = MultiElementSubsetState(indices_dict=indices_dict)
         mode = EditSubsetMode()
-        mode.update(self.viewer._data, subset_state, focus_data=list(indices_dict)[0])
+        if len(indices_dict) > 0:
+            mode.update(self.viewer._data, subset_state, focus_data=list(indices_dict)[0])
 
 
 class MultiElementSubsetState(SubsetState):

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -63,6 +63,17 @@ class BaseVispyViewer(DataViewer):
         self.status_label = None
         self.client = None
 
+        # When layer artists are removed from the layer artist container, we need
+        # to make sure we remove matching layer states in the viewer state
+        # layers attribute.
+        self._layer_artist_container.on_changed(nonpartial(self._sync_state_layers))
+
+    def _sync_state_layers(self):
+        # Remove layer state objects that no longer have a matching layer
+        for layer_state in self.state.layers:
+            if layer_state.layer not in self._layer_artist_container:
+                self.state.layers.remove(layer_state)
+
     def register_to_hub(self, hub):
 
         super(BaseVispyViewer, self).register_to_hub(hub)

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -136,7 +136,10 @@ class MultiColorScatter(scene.visuals.Markers):
                 sizes.append(size)
 
         if len(data) == 0:
+            self.visible = False
             return
+        else:
+            self.visible = True
 
         data = np.vstack(data)
         colors = np.vstack(colors)

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -58,7 +58,7 @@ class VispyVolumeViewer(BaseVispyViewer):
 
             # Assume that the user wants a scatter plot overlay
 
-            layer_artist = ScatterLayerArtist(data, vispy_viewer=self)
+            layer_artist = ScatterLayerArtist(layer=data, vispy_viewer=self)
             self._vispy_widget._update_limits()
 
         elif data.ndim == 3:


### PR DESCRIPTION
When layer artists are removed, the layer state should be removed too. The issue however is that clear is called both when a layer artist is removed and when attributes are incompatible - I think we need to separate those two use cases so that they don't both call ``clear``.