### PR TITLE
Fix 'Data not yet set' error in 3D scatter viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 0.11 (unreleased)
 -----------------
 
+- Fix a bug that caused an error when adding a dataset with an incompatible
+  subset to a new 3D scatter viewer. [#323]
+
 - Improve how we deal with reaching the limit of the number of free slots
   in the volume viewer. [#321]
 

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -30,7 +30,10 @@ class VispyScatterViewer(BaseVispyViewer):
 
         if added:
             if first_layer_artist:
-                self.state.set_limits(*self._layer_artist_container[0].default_limits)
+                # The above call to add_data may have added subset layers, some
+                # of which may be incompatible with the data, so we need to now
+                # explicitly use the layer for the actual data object.
+                self.state.set_limits(*self._layer_artist_container[data][0].default_limits)
                 self._ready_draw = True
 
         return added

--- a/glue_vispy_viewers/scatter/scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/scatter_viewer.py
@@ -33,7 +33,8 @@ class VispyScatterViewer(BaseVispyViewer):
                 # The above call to add_data may have added subset layers, some
                 # of which may be incompatible with the data, so we need to now
                 # explicitly use the layer for the actual data object.
-                self.state.set_limits(*self._layer_artist_container[data][0].default_limits)
+                layer = self._layer_artist_container[data][0]
+                self.state.set_limits(*layer.default_limits)
                 self._ready_draw = True
 
         return added

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -199,7 +199,7 @@ def test_scatter_remove_layer_artists(tmpdir):
     ga2.close()
 
 
-def test_scatter_add_data_with_incompatible_subsets(tmpdir):
+def test_add_data_with_incompatible_subsets(tmpdir):
 
     # Regression test for a bug that an error when adding a dataset with an
     # incompatible subset to a 3D scatter viewer.

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -197,3 +197,25 @@ def test_scatter_remove_layer_artists(tmpdir):
     ga2 = GlueApplication.restore_session(session_file)
     ga2.show()
     ga2.close()
+
+
+def test_scatter_add_data_with_incompatible_subsets(tmpdir):
+
+    # Regression test for a bug that an error when adding a dataset with an
+    # incompatible subset to a 3D scatter viewer.
+
+    data1 = Data(label="Data 1", x=[1, 2, 3])
+    data2 = Data(label="Data 2", y=[4, 5, 6])
+
+    dc = DataCollection([data1, data2])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    # Subset is defined in terms of data2, so it's an incompatible subset
+    # for data1
+    dc.new_subset_group(subset_state=data2.id['y'] > 0.5, label='subset 1')
+
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data1)
+
+    ga.close()

--- a/glue_vispy_viewers/volume/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/tests/test_volume_viewer.py
@@ -221,3 +221,22 @@ def test_remove_subset_group():
     dc.remove_subset_group(dc.subset_groups[0])
 
     ga.close()
+
+
+def test_add_data_with_incompatible_subsets(tmpdir):
+
+    data1 = Data(label="Data 1", x=np.arange(24).reshape((4, 3, 2)))
+    data2 = Data(label="Data 2", y=np.arange(24).reshape((4, 3, 2)))
+
+    dc = DataCollection([data1, data2])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    # Subset is defined in terms of data2, so it's an incompatible subset
+    # for data1
+    dc.new_subset_group(subset_state=data2.id['y'] > 0.5, label='subset 1')
+
+    volume = ga.new_data_viewer(VispyVolumeViewer)
+    volume.add_data(data1)
+
+    ga.close()

--- a/glue_vispy_viewers/volume/volume_viewer.py
+++ b/glue_vispy_viewers/volume/volume_viewer.py
@@ -175,7 +175,11 @@ class VispyVolumeViewer(BaseVispyViewer):
                 self._vispy_widget._update_limits()
 
             if first_layer_artist:
-                self.state.set_limits(*self._layer_artist_container[0].bbox)
+                # The above call to add_data may have added subset layers, some
+                # of which may be incompatible with the data, so we need to now
+                # explicitly use the layer for the actual data object.
+                layer = self._layer_artist_container[data][0]
+                self.state.set_limits(*layer.bbox)
                 self._ready_draw = True
                 self._update_slice_transform()
 


### PR DESCRIPTION
This occurred when adding a dataset with incompatible subsets to a new 3D scatter viewer.