### PR TITLE
Fixed bug with clipping and cmap mode in scatter viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 0.11 (unreleased)
 -----------------
 
+- Fix a bug that caused crashes when not all scatter points were inside the
+  3D scatter viewer box (due e.g. to panning and/or zooming) and color-coding
+  of points was used. [#326]
+
 - Fix a bug that caused an error when adding a dataset with an incompatible
   subset to a new 3D scatter viewer. [#323]
 

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -118,7 +118,10 @@ class MultiColorScatter(scene.visuals.Markers):
                     rgba = np.hstack([layer['color'], 1])
                     rgba = np.repeat(rgba, n_points).reshape(4, -1).transpose()
                 else:
-                    rgba = layer['color'].copy()
+                    if layer['mask'] is None:
+                        rgba = layer['color'].copy()
+                    else:
+                        rgba = layer['color'][layer['mask']]
 
                 rgba[:, 3] *= layer['alpha']
 

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -219,3 +219,26 @@ def test_add_data_with_incompatible_subsets(tmpdir):
     scatter.add_data(data1)
 
     ga.close()
+
+
+def test_not_all_points_inside_limits(tmpdir):
+
+    # Regression test for a bug that occurred when not all points were inside
+    # the visible limits and the color or size mode is linear.
+
+    data1 = Data(label="Data", x=[1, 2, 3])
+
+    dc = DataCollection([data1])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data1)
+
+    scatter.state.layers[0].color_mode = 'Linear'
+    scatter.state.layers[0].size_mode = 'Linear'
+
+    scatter.state.x_min = -0.1
+    scatter.state.x_max = 2.1
+
+    ga.close()


### PR DESCRIPTION
Fixed a bug that caused issues when not all scatter points were visible inside the box and color-coding of points was used.

Fixes https://github.com/glue-viz/glue-vispy-viewers/issues/324
Fixes https://github.com/glue-viz/glue-vispy-viewers/issues/325