### PR TITLE
Fix compatibility with latest developer version of glue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   pixel grid together. Now also requires datasets to always be linked
   in order to be shown in the same viewer. [#335, #337]
 
+- Fix compatibility with the latest developer version of glue. [#339]
+
 0.11 (2018-11-14)
 -----------------
 

--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -38,4 +38,4 @@ class VispyOptionsWidget(QtWidgets.QWidget):
             self.ui.label_reference_data.hide()
             self.ui.combosel_reference_data.hide()
 
-        autoconnect_callbacks_to_qt(viewer_state, self.ui, connect_kwargs)
+        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui, connect_kwargs)

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -24,7 +24,7 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
 
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.)),
                           'value_step': dict(value_range=(1, 10))}
-        autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
+        self._connections = autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
 
 # if __name__ == "__main__":

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -28,7 +28,7 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
 
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.)),
                           'value_size_scaling': dict(value_range=(0.1, 10), log=True)}
-        autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
+        self._connections = autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
         # Set initial values
         self._update_size_mode()

--- a/glue_vispy_viewers/volume/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/layer_style_widget.py
@@ -31,7 +31,7 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
 
         # autoconnect needs to come after setting up the component IDs
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.))}
-        autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
+        self._connections = autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
         # Set up radio buttons for subset mode selection if this is a subset
         if isinstance(self.layer, Subset):


### PR DESCRIPTION
This adds the code to keep references to the connection items that are now needed (otherwise the connections get disconnected when the variable goes out of scope)