### PR TITLE
Add vectors and error bars

### DIFF
--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -106,6 +106,8 @@ class ScatterLayerArtist(VispyLayerArtist):
         Clear the visualization for this layer
         """
         self._multiscat.set_data_values(self.id, [], [], [])
+        self._multiscat.set_errors(self.id, [])
+        self._multiscat.set_vectors(self.id, None)
 
     def remove(self):
         """
@@ -249,6 +251,7 @@ class ScatterLayerArtist(VispyLayerArtist):
             self._multiscat.set_vectors(self.id, vector_points)
         else:
             self._multiscat.set_vectors(self.id, None)
+        self.redraw()
 
     def _update_visibility(self):
         self._multiscat.set_visible(self.id, self.visible)

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -199,32 +199,25 @@ class ScatterLayerArtist(VispyLayerArtist):
 
     def _update_errors(self):
         orig_points = self._multiscat.layers[self.id]['data']
-        num_points = orig_points.shape[0]
         errors = []
 
         if self.state.xerr_visible:
-            line_points = np.zeros((num_points, 6))
+            line_points = np.tile(orig_points, (1, 2))
             err = self.layer[self.state.xerr_attribute].ravel()
-            line_points[:, :3] = orig_points
-            line_points[:, 3:] = orig_points
             line_points[:, 0] -= err
             line_points[:, 3] += err
             errors.append(line_points)
 
         if self.state.yerr_visible:
-            line_points = np.zeros((num_points, 6))
+            line_points = np.tile(orig_points, (1, 2))
             err = self.layer[self.state.yerr_attribute].ravel()
-            line_points[:, :3] = orig_points
-            line_points[:, 3:] = orig_points
             line_points[:, 1] -= err
             line_points[:, 4] += err
             errors.append(line_points)
 
         if self.state.zerr_visible:
-            line_points = np.zeros((num_points, 6))
+            line_points = np.tile(orig_points, (1, 2))
             err = self.layer[self.state.zerr_attribute].ravel()
-            line_points[:, :3] = orig_points
-            line_points[:, 3:] = orig_points
             line_points[:, 2] -= err
             line_points[:, 5] += err
             errors.append(line_points)

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -9,17 +9,14 @@ from .multi_scatter import MultiColorScatter
 from .layer_state import ScatterLayerState
 from ..common.layer_artist import VispyLayerArtist
 
-from vispy.scene.visuals import Line, Arrow
-
-from matplotlib.colors import ColorConverter
-
 COLOR_PROPERTIES = set(['color_mode', 'cmap_attribute', 'cmap_vmin', 'cmap_vmax', 'cmap', 'color'])
 SIZE_PROPERTIES = set(['size_mode', 'size_attribute', 'size_vmin', 'size_vmax',
                        'size_scaling', 'size'])
+ERROR_PROPERTIES = set(['xerr_visible', 'yerr_visible', 'zerr_visible', 'xerr_attribute', 'yerr_attribute', 'zerr_attribute'])
+VECTOR_PROPERTIES = set(['vector_visible', 'vx_attribute', 'vy_attribute', 'vz_attribute', 'vector_scaling', 'vector_origin'])
+ARROW_PROPERTIES = set(['vector_arrowhead'])
 ALPHA_PROPERTIES = set(['alpha'])
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'z_att'])
-ERROR_PROPERTIES = set(['xerr_visible', 'yerr_visible', 'zerr_visible', 'xerr_attribute', 'yerr_attribute', 'zerr_attribute'])
-VECTOR_PROPERTIES = set(['vector_visible', 'vx_attribute', 'vy_attribute', 'vz_attribute', 'vector_scaling', 'vector_origin', 'vector_arrowhead'])
 VISIBLE_PROPERTIES = set(['visible'])
 
 
@@ -70,8 +67,6 @@ class ScatterLayerArtist(VispyLayerArtist):
         self._multiscat.allocate(self.id)
         self._multiscat.set_zorder(self.id, self.get_zorder)
 
-        self._error_vector_widget = Arrow(connect="segments", parent=self._multiscat)
-
         # Watch for changes in the viewer state which would require the
         # layers to be redrawn
         self._viewer_state.add_global_callback(self._update_scatter)
@@ -109,7 +104,6 @@ class ScatterLayerArtist(VispyLayerArtist):
         Clear the visualization for this layer
         """
         self._multiscat.set_data_values(self.id, [], [], [])
-        self._error_vector_widget.set_data(pos=[], arrows=[])
 
     def remove(self):
         """
@@ -143,44 +137,23 @@ class ScatterLayerArtist(VispyLayerArtist):
             size_data[np.isnan(data)] = 0.
             self._multiscat.set_size(self.id, size_data)
 
-    def _compute_cmap(self):
-        if self.state.color_mode is None or self.state.color_mode == 'Fixed':
-            self._color_data = None
-        data = self.layer[self.state.cmap_attribute].ravel()
-        if isinstance(data, categorical_ndarray):
-            data = data.codes
-        if self.state.cmap_vmax == self.state.cmap_vmin:
-            cmap_data = np.ones(data.shape) * 0.5
-        else:
-            cmap_data = ((data - self.state.cmap_vmin) /
-                         (self.state.cmap_vmax - self.state.cmap_vmin))
-        cmap_data = self.state.cmap(cmap_data)
-        cmap_data[:, 3][np.isnan(data)] = 0.
-        self._color_data = cmap_data
-
     def _update_colors(self):
         if self.state.color_mode is None:
             pass
         elif self.state.color_mode == 'Fixed':
             self._multiscat.set_color(self.id, self.state.color)
         else:
-            if self._color_data is None:
-                self._compute_cmap()
-            self._multiscat.set_color(self.id, self._color_data)
-
-    def _update_errors_vectors_colors(self):
-        if self.state.color_mode is None:
-            pass
-        elif self.state.color_mode == 'Fixed':
-            color = ColorConverter.to_rgba(self.state.color, alpha=self.state.alpha)
-            self._error_vector_widget.set_data(color=color)
-            self._error_vector_widget.arrow_color=color
-        else:
-            if self._color_data is None:
-                self._compute_cmap()
-            res = self._get_cmap_array(self._color_data, self._error_vector_widget.pos.shape[0])
-            self._error_vector_widget.set_data(color=res)
-            self._error_vector_widget.arrow_color=self._color_data*self.state.alpha
+            data = self.layer[self.state.cmap_attribute].ravel()
+            if isinstance(data, categorical_ndarray):
+                data = data.codes
+            if self.state.cmap_vmax == self.state.cmap_vmin:
+                cmap_data = np.ones(data.shape) * 0.5
+            else:
+                cmap_data = ((data - self.state.cmap_vmin) /
+                             (self.state.cmap_vmax - self.state.cmap_vmin))
+            cmap_data = self.state.cmap(cmap_data)
+            cmap_data[:, 3][np.isnan(data)] = 0.
+            self._multiscat.set_color(self.id, cmap_data)
 
     def _update_alpha(self):
         self._multiscat.set_alpha(self.id, self.state.alpha)
@@ -220,69 +193,69 @@ class ScatterLayerArtist(VispyLayerArtist):
 
         self.redraw()
 
+    def _update_errors(self):
+        orig_points = self._multiscat.layers[self.id]['data']
+        num_points = orig_points.shape[0]
+        errors = []
+
+        if self.state.xerr_visible:
+            line_points = np.zeros((num_points, 6))
+            err = self.layer[self.state.xerr_attribute].ravel()
+            line_points[:, :3] = orig_points
+            line_points[:, 3:] = orig_points
+            line_points[:, 0] -= err
+            line_points[:, 3] += err
+            errors.append(line_points)
+
+        if self.state.yerr_visible:
+            line_points = np.zeros((num_points, 6))
+            err = self.layer[self.state.yerr_attribute].ravel()
+            line_points[:, :3] = orig_points
+            line_points[:, 3:] = orig_points
+            line_points[:, 1] -= err
+            line_points[:, 4] += err
+            errors.append(line_points)
+
+        if self.state.zerr_visible:
+            line_points = np.zeros((num_points, 6))
+            err = self.layer[self.state.zerr_attribute].ravel()
+            line_points[:, :3] = orig_points
+            line_points[:, 3:] = orig_points
+            line_points[:, 2] -= err
+            line_points[:, 5] += err
+            errors.append(line_points)
+
+        self._multiscat.set_errors(self.id, errors)
+        self.redraw()
+
+    def _update_vectors(self):
+        if self.state.vector_visible:
+            offsets = {'tail': (0, 1), 'middle': (-0.5, 0.5), 'tip': (-1, 0)}
+            orig_points = self._multiscat.layers[self.id]['data']
+            vector_points = np.zeros((orig_points.shape[0], 6))
+            vec_offset = offsets[self.state.vector_origin]
+            scale = self.state.vector_scaling
+            vx = self.layer[self.state.vx_attribute].ravel()
+            vector_points[:, 0] = orig_points[:, 0] + vec_offset[0] * vx * scale
+            vector_points[:, 3] = orig_points[:, 0] + vec_offset[1] * vx * scale
+            vy = self.layer[self.state.vy_attribute].ravel()
+            vector_points[:, 1] = orig_points[:, 1] + vec_offset[0] * vy * scale
+            vector_points[:, 4] = orig_points[:, 1] + vec_offset[1] * vy * scale
+            vz = self.layer[self.state.vz_attribute].ravel()
+            vector_points[:, 2] = orig_points[:, 2] + vec_offset[0] * vz * scale
+            vector_points[:, 5] = orig_points[:, 2] + vec_offset[1] * vz * scale
+            self._multiscat.set_vectors(self.id, vector_points)
+        else:
+            self._multiscat.set_vectors(self.id, None)
+
+
     def _update_visibility(self):
         self._multiscat.set_visible(self.id, self.visible)
         self.redraw()
 
-    def _update_errors_vectors(self):
-        offsets = {'tail': (0, 1), 'middle': (-0.5, 0.5), 'tip': (-1, 0)}
-        orig_points = self._multiscat.layers[self.id]['data']
-        num_points = orig_points.shape[0]
-        num_bars = (self.state.xerr_visible + self.state.yerr_visible + self.state.zerr_visible \
-                    + self.state.vector_visible) * num_points
-        if not self.state.visible or num_bars < 0:
-            self._error_vector_widget.visible = False
-            return
-        self._error_vector_widget.visible = True
-        line_points = np.zeros((2*num_bars,3))
-        arrow_points = np.zeros((self.state.vector_visible*num_points, 6))
-        offset = 0
-        if self.state.xerr_visible:
-            err = self.layer[self.state.xerr_attribute].ravel()
-            line_points[offset  :offset+num_points*2:2, :] = orig_points
-            line_points[offset+1:offset+num_points*2:2, :] = orig_points
-            line_points[offset  :offset+num_points*2:2, 0] -= err
-            line_points[offset+1:offset+num_points*2:2, 0] += err
-            offset += 2*num_points
-        if self.state.yerr_visible:
-            err = self.layer[self.state.yerr_attribute].ravel()
-            line_points[offset:offset + num_points * 2:2, :] = orig_points
-            line_points[offset + 1:offset + num_points * 2:2, :] = orig_points
-            line_points[offset:offset + num_points * 2:2, 1] -= err
-            line_points[offset + 1:offset + num_points * 2:2, 1] += err
-            offset += 2 * num_points
-        if self.state.zerr_visible:
-            err = self.layer[self.state.zerr_attribute].ravel()
-            line_points[offset  :offset+num_points*2:2, :] = orig_points
-            line_points[offset+1:offset+num_points*2:2, :] = orig_points
-            line_points[offset  :offset+num_points*2:2, 2] -= err
-            line_points[offset+1:offset+num_points*2:2, 2] += err
-            offset += 2*num_points
-        if self.state.vector_visible:
-            vec_offset = offsets[self.state.vector_origin]
-            scale = self.state.vector_scaling
-            vx = self.layer[self.state.vx_attribute].ravel()
-            arrow_points[:, 0] = orig_points[:, 0] + vec_offset[0] * vx * scale
-            arrow_points[:, 3] = orig_points[:, 0] + vec_offset[1] * vx * scale
-            vy = self.layer[self.state.vy_attribute].ravel()
-            arrow_points[:, 1] = orig_points[:, 1] + vec_offset[0] * vy * scale
-            arrow_points[:, 4] = orig_points[:, 1] + vec_offset[1] * vy * scale
-            vz = self.layer[self.state.vz_attribute].ravel()
-            arrow_points[:, 2] = orig_points[:, 2] + vec_offset[0] * vz * scale
-            arrow_points[:, 5] = orig_points[:, 2] + vec_offset[1] * vz * scale
-            line_points[offset:,:] = arrow_points.reshape(-1,3)
-        self._error_vector_widget.set_data(pos=line_points, arrows=arrow_points if self.state.vector_arrowhead else [])
-
-    def _get_cmap_array(self, color_data, dest_size):
-        res = np.zeros((dest_size, color_data.shape[1]))
-        offset = 0
-        while offset < dest_size:
-            res[offset  :offset+color_data.shape[0]*2:2] = color_data
-            res[offset+1:offset+color_data.shape[0]*2:2] = color_data
-            offset += 2*color_data.shape[0]
-        res[:,3] *= self.state.alpha
-        return res
-
+    def _update_arrow_head(self):
+        self._multiscat.set_draw_arrows(self.id, self.state.vector_arrowhead)
+        self.redraw()
 
     @property
     def default_limits(self):
@@ -334,26 +307,23 @@ class ScatterLayerArtist(VispyLayerArtist):
         if force or len(changed & SIZE_PROPERTIES) > 0:
             self._update_sizes()
 
+        if force or len(changed & ERROR_PROPERTIES) > 0:
+            self._update_errors()
+
+        if force or len(changed & VECTOR_PROPERTIES) > 0:
+            self._update_vectors()
+
         if force or len(changed & COLOR_PROPERTIES) > 0:
-            self._color_data = None
             self._update_colors()
-            self._update_errors_vectors_colors()
 
         if force or len(changed & ALPHA_PROPERTIES) > 0:
             self._update_alpha()
-            self._update_errors_vectors_colors()
 
         if force or len(changed & VISIBLE_PROPERTIES) > 0:
             self._update_visibility()
-            self._update_errors_vectors()
 
-        if force or len(changed & ERROR_PROPERTIES) > 0:
-            self._update_errors_vectors()
-            self._update_errors_vectors_colors()
-
-        if force or len(changed & VECTOR_PROPERTIES) > 0:
-            self._update_errors_vectors()
-            self._update_errors_vectors_colors()
+        if force or len(changed & ARROW_PROPERTIES) > 0:
+            self._update_arrow_head()
 
     def update(self):
         with self._multiscat.delay_update():

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -12,8 +12,10 @@ from ..common.layer_artist import VispyLayerArtist
 COLOR_PROPERTIES = set(['color_mode', 'cmap_attribute', 'cmap_vmin', 'cmap_vmax', 'cmap', 'color'])
 SIZE_PROPERTIES = set(['size_mode', 'size_attribute', 'size_vmin', 'size_vmax',
                        'size_scaling', 'size'])
-ERROR_PROPERTIES = set(['xerr_visible', 'yerr_visible', 'zerr_visible', 'xerr_attribute', 'yerr_attribute', 'zerr_attribute'])
-VECTOR_PROPERTIES = set(['vector_visible', 'vx_attribute', 'vy_attribute', 'vz_attribute', 'vector_scaling', 'vector_origin'])
+ERROR_PROPERTIES = set(['xerr_visible', 'yerr_visible', 'zerr_visible',
+                        'xerr_attribute', 'yerr_attribute', 'zerr_attribute'])
+VECTOR_PROPERTIES = set(['vector_visible', 'vx_attribute', 'vy_attribute', 'vz_attribute',
+                         'vector_scaling', 'vector_origin'])
 ARROW_PROPERTIES = set(['vector_arrowhead'])
 ALPHA_PROPERTIES = set(['alpha'])
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'z_att'])
@@ -247,7 +249,6 @@ class ScatterLayerArtist(VispyLayerArtist):
             self._multiscat.set_vectors(self.id, vector_points)
         else:
             self._multiscat.set_vectors(self.id, None)
-
 
     def _update_visibility(self):
         self._multiscat.set_visible(self.id, self.visible)

--- a/glue_vispy_viewers/scatter/layer_state.py
+++ b/glue_vispy_viewers/scatter/layer_state.py
@@ -26,6 +26,13 @@ class ScatterLayerState(VispyLayerState):
     cmap_vmax = CallbackProperty()
     cmap = CallbackProperty()
 
+    xerr_visible = CallbackProperty(False)
+    xerr_attribute = SelectionCallbackProperty()
+    yerr_visible = CallbackProperty(False)
+    yerr_attribute = SelectionCallbackProperty()
+    zerr_visible = CallbackProperty(False)
+    zerr_attribute = SelectionCallbackProperty()
+
     size_limits_cache = CallbackProperty({})
     cmap_limits_cache = CallbackProperty({})
 
@@ -43,6 +50,9 @@ class ScatterLayerState(VispyLayerState):
 
         self.size_att_helper = ComponentIDComboHelper(self, 'size_attribute')
         self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_attribute')
+        self.xerr_att_helper = ComponentIDComboHelper(self, 'xerr_attribute')
+        self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_attribute')
+        self.zerr_att_helper = ComponentIDComboHelper(self, 'zerr_attribute')
 
         self.size_lim_helper = StateAttributeLimitsHelper(self, attribute='size_attribute',
                                                           lower='size_vmin', upper='size_vmax',
@@ -63,13 +73,14 @@ class ScatterLayerState(VispyLayerState):
     def _on_layer_change(self, layer=None):
 
         with delay_callback(self, 'cmap_vmin', 'cmap_vmax', 'size_vmin', 'size_vmax'):
-
+            helpers = [self.size_att_helper, self.cmap_att_helper, self.xerr_att_helper,
+                       self.yerr_att_helper, self.zerr_att_helper]
             if self.layer is None:
-                self.cmap_att_helper.set_multiple_data([])
-                self.size_att_helper.set_multiple_data([])
+                for helper in helpers:
+                    helper.set_multiple_data([])
             else:
-                self.cmap_att_helper.set_multiple_data([self.layer])
-                self.size_att_helper.set_multiple_data([self.layer])
+                for helper in helpers:
+                    helper.set_multiple_data([self.layer])
 
     def update_priority(self, name):
         return 0 if name.endswith(('vmin', 'vmax')) else 1

--- a/glue_vispy_viewers/scatter/layer_state.py
+++ b/glue_vispy_viewers/scatter/layer_state.py
@@ -57,13 +57,13 @@ class ScatterLayerState(VispyLayerState):
 
         self.size_att_helper = ComponentIDComboHelper(self, 'size_attribute')
         self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_attribute')
-        self.xerr_att_helper = ComponentIDComboHelper(self, 'xerr_attribute')
-        self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_attribute')
-        self.zerr_att_helper = ComponentIDComboHelper(self, 'zerr_attribute')
+        self.xerr_att_helper = ComponentIDComboHelper(self, 'xerr_attribute', categorical=False)
+        self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_attribute', categorical=False)
+        self.zerr_att_helper = ComponentIDComboHelper(self, 'zerr_attribute', categorical=False)
 
-        self.vx_att_helper = ComponentIDComboHelper(self, 'vx_attribute')
-        self.vy_att_helper = ComponentIDComboHelper(self, 'vy_attribute')
-        self.vz_att_helper = ComponentIDComboHelper(self, 'vz_attribute')
+        self.vx_att_helper = ComponentIDComboHelper(self, 'vx_attribute', categorical=False)
+        self.vy_att_helper = ComponentIDComboHelper(self, 'vy_attribute', categorical=False)
+        self.vz_att_helper = ComponentIDComboHelper(self, 'vz_attribute', categorical=False)
 
         self.size_lim_helper = StateAttributeLimitsHelper(self, attribute='size_attribute',
                                                           lower='size_vmin', upper='size_vmax',

--- a/glue_vispy_viewers/scatter/layer_state.py
+++ b/glue_vispy_viewers/scatter/layer_state.py
@@ -1,6 +1,5 @@
 from glue.config import colormaps
-from glue.external.echo import (CallbackProperty, SelectionCallbackProperty,
-                                keep_in_sync, delay_callback)
+from echo import CallbackProperty, SelectionCallbackProperty, keep_in_sync, delay_callback
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper
 from ..common.layer_state import VispyLayerState
@@ -33,6 +32,14 @@ class ScatterLayerState(VispyLayerState):
     zerr_visible = CallbackProperty(False)
     zerr_attribute = SelectionCallbackProperty()
 
+    vector_visible = CallbackProperty(False)
+    vx_attribute = SelectionCallbackProperty()
+    vy_attribute = SelectionCallbackProperty()
+    vz_attribute = SelectionCallbackProperty()
+    vector_scaling = CallbackProperty(1)
+    vector_origin = SelectionCallbackProperty(default_index=1)
+    vector_arrowhead = CallbackProperty()
+
     size_limits_cache = CallbackProperty({})
     cmap_limits_cache = CallbackProperty({})
 
@@ -54,6 +61,10 @@ class ScatterLayerState(VispyLayerState):
         self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_attribute')
         self.zerr_att_helper = ComponentIDComboHelper(self, 'zerr_attribute')
 
+        self.vx_att_helper = ComponentIDComboHelper(self, 'vx_attribute')
+        self.vy_att_helper = ComponentIDComboHelper(self, 'vy_attribute')
+        self.vz_att_helper = ComponentIDComboHelper(self, 'vz_attribute')
+
         self.size_lim_helper = StateAttributeLimitsHelper(self, attribute='size_attribute',
                                                           lower='size_vmin', upper='size_vmax',
                                                           cache=self.size_limits_cache)
@@ -61,6 +72,12 @@ class ScatterLayerState(VispyLayerState):
         self.cmap_lim_helper = StateAttributeLimitsHelper(self, attribute='cmap_attribute',
                                                           lower='cmap_vmin', upper='cmap_vmax',
                                                           cache=self.cmap_limits_cache)
+
+        vector_origin_display = {'tail': 'Tail of vector',
+                                 'middle': 'Middle of vector',
+                                 'tip': 'Tip of vector'}
+        ScatterLayerState.vector_origin.set_choices(self, ['tail', 'middle', 'tip'])
+        ScatterLayerState.vector_origin.set_display_func(self, vector_origin_display.get)
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:
@@ -73,8 +90,9 @@ class ScatterLayerState(VispyLayerState):
     def _on_layer_change(self, layer=None):
 
         with delay_callback(self, 'cmap_vmin', 'cmap_vmax', 'size_vmin', 'size_vmax'):
-            helpers = [self.size_att_helper, self.cmap_att_helper, self.xerr_att_helper,
-                       self.yerr_att_helper, self.zerr_att_helper]
+            helpers = [self.size_att_helper, self.cmap_att_helper,
+                       self.xerr_att_helper, self.yerr_att_helper, self.zerr_att_helper,
+                       self.vx_att_helper, self.vy_att_helper, self.vz_att_helper]
             if self.layer is None:
                 for helper in helpers:
                     helper.set_multiple_data([])

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -42,7 +42,6 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
         self.state.add_callback('zerr_visible', self._update_error_vis)
         self.state.add_callback('vector_visible', self._update_vector_vis)
 
-
     def _update_size_mode(self, *args):
 
         if self.state.size_mode == "Fixed":

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -25,19 +25,22 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
         self.layer = layer_artist.layer
 
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.)),
-                          'value_size_scaling': dict(value_range=(0.1, 10), log=True)}
+                          'value_size_scaling': dict(value_range=(0.1, 10), log=True),
+                          'vector_scaling': dict(value_range=(0.1, 10), log=True)}
         self._connections = autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
 
         # Set initial values
         self._update_size_mode()
         self._update_color_mode()
         self._update_error_vis()
+        self._update_vector_vis()
 
         self.state.add_callback('color_mode', self._update_color_mode)
         self.state.add_callback('size_mode', self._update_size_mode)
         self.state.add_callback('xerr_visible', self._update_error_vis)
         self.state.add_callback('yerr_visible', self._update_error_vis)
         self.state.add_callback('zerr_visible', self._update_error_vis)
+        self.state.add_callback('vector_visible', self._update_vector_vis)
 
 
     def _update_size_mode(self, *args):
@@ -70,3 +73,12 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
         self.ui.combosel_xerr_attribute.setEnabled(self.state.xerr_visible)
         self.ui.combosel_yerr_attribute.setEnabled(self.state.yerr_visible)
         self.ui.combosel_zerr_attribute.setEnabled(self.state.zerr_visible)
+
+    def _update_vector_vis(self, *arg):
+        visible = self.state.vector_visible
+        self.ui.combosel_vx_attribute.setEnabled(visible)
+        self.ui.combosel_vy_attribute.setEnabled(visible)
+        self.ui.combosel_vz_attribute.setEnabled(visible)
+        self.ui.value_vector_scaling.setEnabled(visible)
+        self.ui.combosel_vector_origin.setEnabled(visible)
+        self.ui.bool_vector_arrowhead.setEnabled(visible)

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -31,9 +31,14 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
         # Set initial values
         self._update_size_mode()
         self._update_color_mode()
+        self._update_error_vis()
 
         self.state.add_callback('color_mode', self._update_color_mode)
         self.state.add_callback('size_mode', self._update_size_mode)
+        self.state.add_callback('xerr_visible', self._update_error_vis)
+        self.state.add_callback('yerr_visible', self._update_error_vis)
+        self.state.add_callback('zerr_visible', self._update_error_vis)
+
 
     def _update_size_mode(self, *args):
 
@@ -60,3 +65,8 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
             self.ui.spacer_color_label.hide()
             self.ui.color_row_2.show()
             self.ui.color_row_3.show()
+
+    def _update_error_vis(self, *args):
+        self.ui.combosel_xerr_attribute.setEnabled(self.state.xerr_visible)
+        self.ui.combosel_yerr_attribute.setEnabled(self.state.yerr_visible)
+        self.ui.combosel_zerr_attribute.setEnabled(self.state.zerr_visible)

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -446,7 +446,7 @@
         <string/>
        </property>
       </widget>
-      <widget class="QComboBox" name="combosel_xerr_att">
+      <widget class="QComboBox" name="combosel_xerr_attribute">
        <property name="geometry">
         <rect>
          <x>85</x>
@@ -478,7 +478,7 @@
         <string>show y</string>
        </property>
       </widget>
-      <widget class="QComboBox" name="combosel_yerr_att">
+      <widget class="QComboBox" name="combosel_yerr_attribute">
        <property name="geometry">
         <rect>
          <x>85</x>
@@ -510,7 +510,7 @@
         <string>show z</string>
        </property>
       </widget>
-      <widget class="QComboBox" name="combosel_zerr_att">
+      <widget class="QComboBox" name="combosel_zerr_attribute">
        <property name="geometry">
         <rect>
          <x>85</x>

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -29,7 +29,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
@@ -541,7 +541,7 @@
       <attribute name="title">
        <string>Vectors</string>
       </attribute>
-      <widget class="QComboBox" name="combosel_vx_att">
+      <widget class="QComboBox" name="combosel_vx_attribute">
        <property name="geometry">
         <rect>
          <x>45</x>
@@ -576,7 +576,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="QComboBox" name="combosel_vy_att">
+      <widget class="QComboBox" name="combosel_vy_attribute">
        <property name="geometry">
         <rect>
          <x>45</x>
@@ -592,7 +592,7 @@
       <widget class="QCheckBox" name="bool_vector_visible">
        <property name="geometry">
         <rect>
-         <x>45</x>
+         <x>50</x>
          <y>20</y>
          <width>245</width>
          <height>13</height>
@@ -690,7 +690,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="QComboBox" name="combosel_vz_att">
+      <widget class="QComboBox" name="combosel_vz_attribute">
        <property name="geometry">
         <rect>
          <x>45</x>
@@ -728,8 +728,8 @@
       <widget class="QCheckBox" name="bool_vector_arrowhead">
        <property name="geometry">
         <rect>
-         <x>45</x>
-         <y>165</y>
+         <x>170</x>
+         <y>18</y>
          <width>205</width>
          <height>17</height>
         </rect>
@@ -754,8 +754,8 @@
       <widget class="QLabel" name="label_12">
        <property name="geometry">
         <rect>
-         <x>2</x>
-         <y>165</y>
+         <x>120</x>
+         <y>18</y>
          <width>39</width>
          <height>17</height>
         </rect>

--- a/glue_vispy_viewers/scatter/layer_style_widget.ui
+++ b/glue_vispy_viewers/scatter/layer_style_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>259</width>
-    <height>146</height>
+    <width>269</width>
+    <height>219</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
@@ -377,6 +377,434 @@
         </spacer>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Errors</string>
+      </attribute>
+      <widget class="QLabel" name="label_5">
+       <property name="geometry">
+        <rect>
+         <x>1</x>
+         <y>25</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>show x</string>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_yerr_visible">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>53</y>
+         <width>13</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_warning_errorbar">
+       <property name="geometry">
+        <rect>
+         <x>-15</x>
+         <y>2</y>
+         <width>294</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: #BB2200</string>
+       </property>
+       <property name="text">
+        <string>Warning: adding errorbars may be slow</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_xerr_visible">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>28</y>
+         <width>13</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_xerr_att">
+       <property name="geometry">
+        <rect>
+         <x>85</x>
+         <y>25</y>
+         <width>160</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_6">
+       <property name="geometry">
+        <rect>
+         <x>1</x>
+         <y>50</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>show y</string>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_yerr_att">
+       <property name="geometry">
+        <rect>
+         <x>85</x>
+         <y>50</y>
+         <width>160</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_7">
+       <property name="geometry">
+        <rect>
+         <x>1</x>
+         <y>75</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>show z</string>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_zerr_att">
+       <property name="geometry">
+        <rect>
+         <x>85</x>
+         <y>75</y>
+         <width>160</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_zerr_visible">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>78</y>
+         <width>13</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Vectors</string>
+      </attribute>
+      <widget class="QComboBox" name="combosel_vx_att">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>40</y>
+         <width>205</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_vector_y">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>65</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>vy</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_vy_att">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>65</y>
+         <width>205</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_vector_visible">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>20</y>
+         <width>245</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_warning_vector">
+       <property name="geometry">
+        <rect>
+         <x>-15</x>
+         <y>2</y>
+         <width>294</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: #BB2200</string>
+       </property>
+       <property name="text">
+        <string>Warning: adding vectors may be slow</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_vector_x">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>40</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>vx</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_3">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>20</y>
+         <width>39</width>
+         <height>13</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>show</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_vector_z">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>90</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>vz</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_vz_att">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>90</y>
+         <width>205</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_11">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>140</y>
+         <width>39</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>origin</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_vector_arrowhead">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>165</y>
+         <width>205</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Show arrow</string>
+       </property>
+      </widget>
+      <widget class="QSlider" name="value_vector_scaling">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>115</y>
+         <width>205</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_12">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>165</y>
+         <width>39</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>arrow</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_vector_origin">
+       <property name="geometry">
+        <rect>
+         <x>45</x>
+         <y>140</y>
+         <width>205</width>
+         <height>20</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_13">
+       <property name="geometry">
+        <rect>
+         <x>2</x>
+         <y>115</y>
+         <width>39</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>scaling</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -115,12 +115,13 @@ class MultiColorScatter(scene.visuals.Markers):
             if not layer['visible'] or layer['data'] is None:
                 continue
 
+            input_points = layer['data'].shape[0]
             if layer['mask'] is None:
-                n_points = layer['data'].shape[0]
+                n_points = input_points
             else:
                 n_points = np.sum(layer['mask'])
 
-            if n_points > 0:
+            if  input_points > 0 and n_points > 0:
 
                 # Data
 

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -41,7 +41,7 @@ class MultiColorScatter(scene.visuals.Markers):
                                   'alpha': 1.,
                                   'zorder': lambda: 0,
                                   'size': 10,
-                                  'visible': True,}
+                                  'visible': True}
 
     def deallocate(self, label):
         self.layers.pop(label)
@@ -104,7 +104,7 @@ class MultiColorScatter(scene.visuals.Markers):
         colors = []
         sizes = []
         lines = []
-        line_colors =[]
+        line_colors = []
         arrows = []
         arrow_colors = []
 
@@ -155,25 +155,23 @@ class MultiColorScatter(scene.visuals.Markers):
                         size = layer['size'][layer['mask']]
                 sizes.append(size)
 
-
                 # Error bar and colors
-
                 if layer['errors'] is not None:
                     for error_set in layer['errors']:
                         if layer['mask'] is None:
                             out = error_set
                         else:
                             out = error_set[layer['mask']]
-                        out = out.reshape((-1,3))
+                        out = out.reshape((-1, 3))
                         lines.append(out)
-                        line_colors.append(np.repeat(rgba,2,axis=0))
+                        line_colors.append(np.repeat(rgba, 2, axis=0))
 
                 if layer['vectors'] is not None:
                     if layer['mask'] is None:
                         out = layer['vectors']
                     else:
                         out = layer['vectors'][layer['mask']]
-                    lines.append(out.reshape((-1,3)))
+                    lines.append(out.reshape((-1, 3)))
                     line_colors.append(np.repeat(rgba, 2, axis=0))
                     if layer['draw_arrows']:
                         arrows.append(out)

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -121,7 +121,7 @@ class MultiColorScatter(scene.visuals.Markers):
             else:
                 n_points = np.sum(layer['mask'])
 
-            if  input_points > 0 and n_points > 0:
+            if input_points > 0 and n_points > 0:
 
                 # Data
 

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -121,6 +121,122 @@ def test_scatter_viewer(tmpdir):
 
     ga2.close()
 
+def test_error_bars(tmpdir):
+
+    # Create fake data
+    data = make_test_data()
+
+    # Create fake session
+
+    dc = DataCollection([data])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data)
+    scatter.viewer_size = (400, 500)
+
+    viewer_state = scatter.state
+
+    viewer_state.x_att = data.id['a']
+    viewer_state.y_att = data.id['f']
+    viewer_state.z_att = data.id['z']
+
+    layer_state = viewer_state.layers[0]
+
+    layer_state.xerr_visible = True
+    layer_state.xerr_attribute = data.id['b']
+
+    layer_state.yerr_visible = False
+    layer_state.yerr_attribute = data.id['c']
+
+    layer_state.zerr_visible = True
+    layer_state.zerr_attribute = data.id['d']
+
+
+    # Check that writing a session works as expected.
+
+    session_file = tmpdir.join('test_error_bars.glu').strpath
+    ga.save_session(session_file)
+    ga.close()
+
+    # Now we can check that everything is restored correctly
+
+    ga2 = GlueApplication.restore_session(session_file)
+    ga2.show()
+
+    scatter_r = ga2.viewers[0][0]
+    layer_state = scatter_r.state.layers[0]
+
+    assert layer_state.xerr_visible
+    assert layer_state.xerr_attribute.label == 'b'
+
+    assert not layer_state.yerr_visible
+    assert layer_state.yerr_attribute.label == 'c'
+
+    assert layer_state.zerr_visible
+    assert  layer_state.zerr_attribute.label == 'd'
+    ga2.close()
+
+def test_vectors(tmpdir):
+
+    # Create fake data
+    data = make_test_data()
+
+    # Create fake session
+
+    dc = DataCollection([data])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data)
+    scatter.viewer_size = (400, 500)
+
+    viewer_state = scatter.state
+
+    viewer_state.x_att = data.id['a']
+    viewer_state.y_att = data.id['f']
+    viewer_state.z_att = data.id['z']
+
+    layer_state = viewer_state.layers[0]
+
+    layer_state.vector_visible = True
+    layer_state.vx_attribute = data.id['x']
+    layer_state.vy_attribute = data.id['y']
+    layer_state.vz_attribute = data.id['e']
+    layer_state.vector_scaling = 0.1
+    layer_state.vector_origin = 'tail'
+    layer_state.vector_arrowhead = True
+
+    # Check that writing a session works as expected.
+
+    session_file = tmpdir.join('test_vectors.glu').strpath
+    ga.save_session(session_file)
+    ga.close()
+
+    # Now we can check that everything is restored correctly
+
+    ga2 = GlueApplication.restore_session(session_file)
+    ga2.show()
+
+    scatter_r = ga2.viewers[0][0]
+    layer_state = scatter_r.state.layers[0]
+
+    assert layer_state.vector_visible
+
+    assert layer_state.vx_attribute.label == 'x'
+    assert layer_state.vy_attribute.label == 'y'
+    assert layer_state.vz_attribute.label == 'e'
+
+    assert np.isclose(layer_state.vector_scaling, 0.1)
+
+    assert layer_state.vector_origin == 'tail'
+
+    assert layer_state.vector_arrowhead
+
+    ga2.close()
+
 
 def test_n_dimensional_data():
 

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -121,6 +121,7 @@ def test_scatter_viewer(tmpdir):
 
     ga2.close()
 
+
 def test_error_bars(tmpdir):
 
     # Create fake data
@@ -153,7 +154,6 @@ def test_error_bars(tmpdir):
     layer_state.zerr_visible = True
     layer_state.zerr_attribute = data.id['d']
 
-
     # Check that writing a session works as expected.
 
     session_file = tmpdir.join('test_error_bars.glu').strpath
@@ -175,8 +175,9 @@ def test_error_bars(tmpdir):
     assert layer_state.yerr_attribute.label == 'c'
 
     assert layer_state.zerr_visible
-    assert  layer_state.zerr_attribute.label == 'd'
+    assert layer_state.zerr_attribute.label == 'd'
     ga2.close()
+
 
 def test_vectors(tmpdir):
 


### PR DESCRIPTION
This PR adds support for drawing vectors and error bars for vispy scatter layers. The drawing of the lines is done in the MultiColorScatter to work with multiple layers and reuse the existing masking and coloring work. This PR also adds some tests to make sure that vector and error bar properties in the layer state can be written to and then read from a session file.