### PR TITLE
Update imports for echo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.0.2 (unreleased)
+------------------
+
+- Fix deprecation warnings related to echo with recent versions
+  of glue-core. [#367]
+
 1.0.2 (2020-11-24)
 ------------------
 

--- a/glue_vispy_viewers/common/layer_state.py
+++ b/glue_vispy_viewers/common/layer_state.py
@@ -1,4 +1,4 @@
-from glue.external.echo import CallbackProperty, keep_in_sync
+from echo import CallbackProperty, keep_in_sync
 from glue.core.message import LayerArtistUpdatedMessage
 from glue.viewers.common.state import LayerState
 

--- a/glue_vispy_viewers/common/viewer_options.py
+++ b/glue_vispy_viewers/common/viewer_options.py
@@ -2,7 +2,7 @@ import os
 
 from qtpy import QtWidgets
 
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
+from echo.qt import autoconnect_callbacks_to_qt
 
 from glue.utils.qt import load_ui
 

--- a/glue_vispy_viewers/common/viewer_state.py
+++ b/glue_vispy_viewers/common/viewer_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from echo import (CallbackProperty, SelectionCallbackProperty,
-                                delay_callback, ListCallbackProperty)
+                  delay_callback, ListCallbackProperty)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.viewers.common.state import ViewerState
 

--- a/glue_vispy_viewers/common/viewer_state.py
+++ b/glue_vispy_viewers/common/viewer_state.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from glue.external.echo import (CallbackProperty, SelectionCallbackProperty,
+from echo import (CallbackProperty, SelectionCallbackProperty,
                                 delay_callback, ListCallbackProperty)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.viewers.common.state import ViewerState

--- a/glue_vispy_viewers/common/vispy_data_viewer.py
+++ b/glue_vispy_viewers/common/vispy_data_viewer.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from glue.viewers.common.qt.data_viewer_with_state import DataViewerWithState
-from glue.external.echo import delay_callback
+from echo import delay_callback
 
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt

--- a/glue_vispy_viewers/isosurface/layer_state.py
+++ b/glue_vispy_viewers/isosurface/layer_state.py
@@ -1,5 +1,5 @@
 from glue.config import colormaps
-from glue.external.echo import CallbackProperty, SelectionCallbackProperty, delay_callback
+from echo import CallbackProperty, SelectionCallbackProperty, delay_callback
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper
 

--- a/glue_vispy_viewers/isosurface/layer_style_widget.py
+++ b/glue_vispy_viewers/isosurface/layer_style_widget.py
@@ -3,7 +3,7 @@ import os
 from qtpy import QtWidgets
 
 from glue.utils.qt import load_ui
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
+from echo.qt import autoconnect_callbacks_to_qt
 
 
 class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
@@ -28,7 +28,7 @@ class IsosurfaceLayerStyleWidget(QtWidgets.QWidget):
 # if __name__ == "__main__":
 #
 #     from glue.utils.qt import get_qapp
-#     from glue.external.echo import CallbackProperty
+#     from echo import CallbackProperty
 #
 #     app = get_qapp()
 #

--- a/glue_vispy_viewers/scatter/layer_style_widget.py
+++ b/glue_vispy_viewers/scatter/layer_style_widget.py
@@ -3,7 +3,7 @@ import os
 from qtpy import QtWidgets
 
 from glue.utils.qt import load_ui
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
+from echo.qt import autoconnect_callbacks_to_qt
 
 from glue_vispy_viewers.utils import fix_tab_widget_fontsize
 

--- a/glue_vispy_viewers/tests/data/multiple_volumes_v1.glu
+++ b/glue_vispy_viewers/tests/data/multiple_volumes_v1.glu
@@ -1,6 +1,6 @@
 {
   "CallbackList": {
-    "_type": "glue.external.echo.list.CallbackList",
+    "_type": "echo.list.CallbackList",
     "values": [
       "VolumeLayerState",
       "VolumeLayerState_0",

--- a/glue_vispy_viewers/tests/data/multiple_volumes_v2.glu
+++ b/glue_vispy_viewers/tests/data/multiple_volumes_v2.glu
@@ -1,6 +1,6 @@
 {
   "CallbackList": {
-    "_type": "glue.external.echo.list.CallbackList",
+    "_type": "echo.list.CallbackList",
     "values": [
       "VolumeLayerState",
       "VolumeLayerState_0",

--- a/glue_vispy_viewers/tests/data/scatter_volume_selection.glu
+++ b/glue_vispy_viewers/tests/data/scatter_volume_selection.glu
@@ -1,6 +1,6 @@
 {
   "CallbackList": {
-    "_type": "glue.external.echo.list.CallbackList",
+    "_type": "echo.list.CallbackList",
     "values": [
       "VolumeLayerState",
       "ScatterLayerState",

--- a/glue_vispy_viewers/tests/data/scatter_volume_v1.glu
+++ b/glue_vispy_viewers/tests/data/scatter_volume_v1.glu
@@ -1,12 +1,12 @@
 {
   "CallbackList": {
-    "_type": "glue.external.echo.list.CallbackList",
+    "_type": "echo.list.CallbackList",
     "values": [
       "ScatterLayerState"
     ]
   },
   "CallbackList_0": {
-    "_type": "glue.external.echo.list.CallbackList",
+    "_type": "echo.list.CallbackList",
     "values": [
       "VolumeLayerState"
     ]

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,6 +1,6 @@
 from glue.core import Subset
 from echo import (CallbackProperty, SelectionCallbackProperty,
-                                delay_callback)
+                  delay_callback)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper
 from ..common.layer_state import VispyLayerState

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,5 +1,5 @@
 from glue.core import Subset
-from glue.external.echo import (CallbackProperty, SelectionCallbackProperty,
+from echo import (CallbackProperty, SelectionCallbackProperty,
                                 delay_callback)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper

--- a/glue_vispy_viewers/volume/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/layer_style_widget.py
@@ -5,7 +5,7 @@ from glue.core.subset import Subset
 from qtpy import QtWidgets
 
 from glue.utils.qt import load_ui
-from glue.external.echo.qt import autoconnect_callbacks_to_qt
+from echo.qt import autoconnect_callbacks_to_qt
 
 
 class VolumeLayerStyleWidget(QtWidgets.QWidget):

--- a/glue_vispy_viewers/volume/viewer_state.py
+++ b/glue_vispy_viewers/volume/viewer_state.py
@@ -1,5 +1,5 @@
 from glue.core.data import BaseData
-from glue.external.echo import CallbackProperty, SelectionCallbackProperty
+from echo import CallbackProperty, SelectionCallbackProperty
 from glue_vispy_viewers.common.viewer_state import Vispy3DViewerState
 from glue.core.data_combo_helper import ManualDataComboHelper
 


### PR DESCRIPTION
I thought I had updated these, but apparently not! This should resolve the following warnings:

```
/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/__init__.py:3: UserWarning: glue.external.echo is deprecated, import from echo directly instead
  warnings.warn('glue.external.echo is deprecated, import from echo directly instead')
```