### PR TITLE
Allow axis color to be changed during runtime.

### DIFF
--- a/glue_vispy_viewers/common/axes.py
+++ b/glue_vispy_viewers/common/axes.py
@@ -85,7 +85,7 @@ class AxesVisual3D(object):
 
     @axis_color.setter
     def axis_color(self, value):
-        self.axis.color = value
+        self.axis.set_data(color=value)
 
     @property
     def tick_font_size(self):


### PR DESCRIPTION
While doing some work on the `glue-plotly` 3D scatter exporter, I noticed that it's not possible to change the axis color of an `AxesVisual3D` during runtime. This is due to the fact that the `color` attribute of a `vispy.visuals.line.LineVisual` is a property without a setter. To fix this, this PR changes the axis color to be updated using `set_data` instead.