### PR TITLE
Setup automated changelog generation for release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    authors:
+      - pre-commit-ci
+    labels:
+      - no-changelog-entry-needed
+      - skip-changelog
+
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,8 +32,26 @@ jobs:
 
       envs: |
         # Standard tests
-        - macos: py310-test-dev
+        - linux: py37-test
+        - linux: py38-test
+        - linux: py39-test
+        - linux: py310-test-dev
+
+        - macos: py38-test
+        - macos: py39-test-dev
+        - macos: py310-test
 
         - windows: py38-test
         - windows: py39-test-dev
         - windows: py310-test
+
+  publish:
+    needs: tests
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    with:
+      # Setup PyQt5 deps and headless X server as per pyvista/setup-headless-display-action@v1
+      libraries: '^libxcb.*-dev libxkbcommon-x11-dev xvfb'
+      test_extras: 'test,qt'
+      test_command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & sleep 3; DISPLAY=:99.0 pytest --pyargs glue_vispy_viewers
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -24,29 +24,34 @@ jobs:
     with:
       display: true
       coverage: codecov
+      # The Linux PyQt 5.15 installation requires apt-getting its xcb deps and headless X11 display
       libraries: |
         apt:
-          - libxkbcommon-x11-0
+          - '^libxcb.*-dev'
+          - libxkbcommon-x11-dev
 
       envs: |
         # Standard tests
         - linux: py37-test
-        - linux: py37-test-dev
         - linux: py38-test
+        - linux: py39-test-dev
         - linux: py310-test
 
-        - macos: py37-test
+        - macos: py38-test
         - macos: py39-test
         - macos: py310-test-dev
 
         - windows: py37-test
-        - windows: py38-test-dev
+        - windows: py39-test-dev
         - windows: py310-test
 
   publish:
     needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      libraries: libxkbcommon-x11-0
+      # Setup PyQt5 deps and headless X server as per pyvista/setup-headless-display-action@v1
+      libraries: '^libxcb.*-dev libxkbcommon-x11-dev xvfb'
+      test_extras: 'test,qt'
+      test_command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & sleep 3; DISPLAY=:99.0 pytest --pyargs glue
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,26 +32,8 @@ jobs:
 
       envs: |
         # Standard tests
-        - linux: py37-test
-        - linux: py38-test
-        - linux: py39-test-dev
-        - linux: py310-test
-
-        - macos: py38-test
-        - macos: py39-test
         - macos: py310-test-dev
 
-        - windows: py37-test
+        - windows: py38-test
         - windows: py39-test-dev
         - windows: py310-test
-
-  publish:
-    needs: tests
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-    with:
-      # Setup PyQt5 deps and headless X server as per pyvista/setup-headless-display-action@v1
-      libraries: '^libxcb.*-dev libxkbcommon-x11-dev xvfb'
-      test_extras: 'test,qt'
-      test_command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & sleep 3; DISPLAY=:99.0 pytest --pyargs glue
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,33 @@
+# This workflow takes the GitHub release notes and updates the changelog on the
+# main branch with the body of the release notes, thereby keeping a log in
+# the git repo of the changes.
+
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.name }}
+          path-to-changelog: CHANGES.md
+
+      - name: Commit updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,306 +1,373 @@
-1.0.5 (2021-10-28)
-------------------
+# Full changelog
 
-- Fix compatibility with vispy v0.9.1 and later. [#370]
+## [1.0.5](https://github.com/glue-viz/glue-vispy-viewers/compare/v1.0.4...v1.0.5) - 2021-10-28
 
-1.0.4 (2021-10-17)
-------------------
+### What's Changed
 
-- Fix compatibility with vispy v0.9.0. [#369]
+#### Bug Fixes
 
-1.0.3 (2021-07-27)
-------------------
+- Include vispy vertex shader to fix compatibility with vispy v0.9.1 and later. [https://github.com/glue-viz/glue-vispy-viewers/pull/370]
+
+## [1.0.4](https://github.com/glue-viz/glue-vispy-viewers/compare/v1.0.3...v1.0.4) - 2021-10-17
+
+#### Bug Fixes
+
+- Fix compatibility with vispy v0.9.0. [https://github.com/glue-viz/glue-vispy-viewers/pull/369]
+
+## [1.0.3](https://github.com/glue-viz/glue-vispy-viewers/compare/v1.0.2...v1.0.3) - 2021-07-27
+
+#### Bug Fixes
 
 - Fix deprecation warnings related to echo with recent versions
-  of glue-core. [#367]
+  of glue-core. [https://github.com/glue-viz/glue-vispy-viewers/pull/367]
 
-1.0.2 (2020-11-24)
-------------------
+## [1.0.2](https://github.com/glue-viz/glue-vispy-viewers/compare/v1.0.1...v1.0.2) - 2020-11-24
 
-- Fix compatibility with latest developer version of vispy. [#363]
+#### Bug Fixes
 
-1.0.1 (2020-10-02)
-------------------
+- Fix compatibility with latest developer version of vispy. [https://github.com/glue-viz/glue-vispy-viewers/pull/363]
 
-- Fix 'flip limits' button in 3D scatter plot. [#361]
+## [1.0.1](https://github.com/glue-viz/glue-vispy-viewers/compare/v1.0.0...v1.0.1) - 2020-10-02
 
-- Fix the visual appearance of vectors. [#362]
+#### Bug Fixes
 
-1.0.0 (2020-09-17)
-------------------
+- Fix 'flip limits' button in 3D scatter plot. [https://github.com/glue-viz/glue-vispy-viewers/pull/361]
 
-- Drop support for Python < 3.6. [#351, #353]
+- Fix the visual appearance of vectors. [https://github.com/glue-viz/glue-vispy-viewers/pull/362]
 
-- No longer bundle vispy, and instead depend on the
-  latest stable release. [#351]
+## [1.0.0](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.12.1...v1.0.0) - 2020-09-17
+
+### What's Changed
+
+#### New Features
 
 - Add initial support for vectors and error bars.
-  [#358]
+  [https://github.com/glue-viz/glue-vispy-viewers/pull/358]
 
-0.12.2 (2019-06-24)
--------------------
+#### Other Changes
 
-- Fixed __version__ variable which was set to 'undefined'. [#344]
+- Drop support for Python < 3.6. [https://github.com/glue-viz/glue-vispy-viewers/pull/351, https://github.com/glue-viz/glue-vispy-viewers/pull/353]
 
-- Fixed configuration for tox testing tool. [#344]
+- No longer bundle vispy, and instead depend on the
+  latest stable release. [https://github.com/glue-viz/glue-vispy-viewers/pull/351]
 
-0.12.1 (2019-06-23)
--------------------
+## [0.12.2](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.12.1...v0.12.2) - 2019-06-24
+
+#### Bug Fixes
+
+- Fixed __version__ variable which was set to 'undefined'. [https://github.com/glue-viz/glue-vispy-viewers/pull/344]
+
+- Fixed configuration for tox testing tool. [https://github.com/glue-viz/glue-vispy-viewers/pull/344]
+
+## [0.12.1](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.12...v0.12.1) - 2019-06-23
+
+#### Bug Fixes
 
 - Fixed missing package data.
 
-0.12 (2019-06-23)
------------------
+## [0.12](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.11...v0.12) - 2019-06-23
+
+### What's Changed
+
+#### New Features
 
 - Make it possible to view datasets that are linked but not on the same
   pixel grid together. Now also requires datasets to always be linked
-  in order to be shown in the same viewer. [#335, #337]
+  in order to be shown in the same viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/335, https://github.com/glue-viz/glue-vispy-viewers/pull/337]
 
-- Fix compatibility with the latest developer version of glue. [#339, #342]
+#### Bug Fixes
+
+- Fix compatibility with the latest developer version of glue. [https://github.com/glue-viz/glue-vispy-viewers/pull/339, https://github.com/glue-viz/glue-vispy-viewers/pull/342]
 
 - Fix bug with hidden layers in the 3D scatter viewer becoming visible after
-  saving and loading session file. [#340]
+  saving and loading session file. [https://github.com/glue-viz/glue-vispy-viewers/pull/340]
 
-0.11 (2018-11-14)
------------------
+## [0.11](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.10...v0.11) - 2018-11-14
 
-- Fixed the home button in the toolbar to reset limits in addition to the
-  viewing angle. [#327]
+### What's Changed
 
-- Fix a bug that caused crashes when not all scatter points were inside the
-  3D scatter viewer box (due e.g. to panning and/or zooming) and color-coding
-  of points was used. [#326]
-
-- Fix a bug that caused an error when adding a dataset with an incompatible
-  subset to a new 3D scatter viewer. [#323]
-
-- Improve how we deal with reaching the limit of the number of free slots
-  in the volume viewer. [#321]
+#### New Features
 
 - Make it so that selection tools are de-selected after use, to be
-  consistent with the core glue behavior. [#320]
-
-- Fixed a bug that caused layers to sometimes non-deterministically be
-  shown/hidden and/or not disappear correctly. [#314]
+  consistent with the core glue behavior. [https://github.com/glue-viz/glue-vispy-viewers/pull/320]
 
 - Implement the 'data' and 'outline' modes for volume rendering of subsets
-  directly in the OpenGL shader. [#310]
+  directly in the OpenGL shader. [https://github.com/glue-viz/glue-vispy-viewers/pull/310]
 
 - Make volume rendering be adaptive in terms of resolution - the buffer used
   for the rendering is a fixed size and the data in the buffer is updated as
-  the user zooms in/out and pans around. [#312]
+  the user zooms in/out and pans around. [https://github.com/glue-viz/glue-vispy-viewers/pull/312]
 
-0.10 (2018-04-27)
------------------
+#### Bug Fixes
+
+- Fixed the home button in the toolbar to reset limits in addition to the
+  viewing angle. [https://github.com/glue-viz/glue-vispy-viewers/pull/327]
+
+- Fix a bug that caused crashes when not all scatter points were inside the
+  3D scatter viewer box (due e.g. to panning and/or zooming) and color-coding
+  of points was used. [https://github.com/glue-viz/glue-vispy-viewers/pull/326]
+
+- Fix a bug that caused an error when adding a dataset with an incompatible
+  subset to a new 3D scatter viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/323]
+
+- Improve how we deal with reaching the limit of the number of free slots
+  in the volume viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/321]
+
+- Fixed a bug that caused layers to sometimes non-deterministically be
+  shown/hidden and/or not disappear correctly. [https://github.com/glue-viz/glue-vispy-viewers/pull/314]
+
+## [0.10](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.9.2...v0.10) - 2018-04-27
+
+### What's Changed
+
+#### New Features
 
 - Use new 3D and flood fill subset state classes from glue to make storing
-  subsets much more efficient. [#301]
-
-- Work around an issue on certain graphics cards which causes volume
-  renderings to not appear correctly but instead of have stripe artifacts. [#303]
+  subsets much more efficient. [https://github.com/glue-viz/glue-vispy-viewers/pull/301]
 
 - Improve performance for volume rendering for arrays larger than 2048
-  along one or more dimensions. [#303]
+  along one or more dimensions. [https://github.com/glue-viz/glue-vispy-viewers/pull/303]
 
 - Improve performance when closing a session that has large volume
-  visualizations. [#307]
+  visualizations. [https://github.com/glue-viz/glue-vispy-viewers/pull/307]
 
-- Improve performance when clipping the data outside the box. [#307]
+- Improve performance when clipping the data outside the box. [https://github.com/glue-viz/glue-vispy-viewers/pull/307]
+
+#### Bug Fixes
+
+- Work around an issue on certain graphics cards which causes volume
+  renderings to not appear correctly but instead of have stripe artifacts. [https://github.com/glue-viz/glue-vispy-viewers/pull/303]
 
 - Fixed a bug that caused layers to be shown/hidden out of sync with
-  checkboxes. [#307]
+  checkboxes. [https://github.com/glue-viz/glue-vispy-viewers/pull/307]
 
 - Fixed a bug that caused circular references to viewers to cause issues
-  after the viewers were closed. [#307]
+  after the viewers were closed. [https://github.com/glue-viz/glue-vispy-viewers/pull/307]
 
-0.9.2 (2018-03-08)
-------------------
+## [0.9.2](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.9.1...v0.9.2) - 2018-03-08
+
+#### Bug Fixes
 
 - Fix bug that caused a crash when adding a volume to a viewer that
-  already had a viewer and scatter layer. [#291]
+  already had a viewer and scatter layer. [https://github.com/glue-viz/glue-vispy-viewers/pull/291]
 
-0.9.1 (2018-01-09)
-------------------
+## [0.9.1](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.9...v0.9.1) - 2018-01-09
 
-- Fix compatibility of 3D viewers with PyQt5 on Linux. [#287]
+#### Bug Fixes
 
-0.9 (2017-10-25)
-----------------
+- Fix compatibility of 3D viewers with PyQt5 on Linux. [https://github.com/glue-viz/glue-vispy-viewers/pull/287]
 
-- Improve performance for volume rendering. [#274]
+## [0.9](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.8...v0.9) - 2017-10-25
 
-- Fix layer artist icon when using colormaps. [#283]
+### What's Changed
+
+#### New Features
+
+- Improve performance for volume rendering. [https://github.com/glue-viz/glue-vispy-viewers/pull/274]
+
+#### Bug Fixes
+
+- Fix layer artist icon when using colormaps. [https://github.com/glue-viz/glue-vispy-viewers/pull/283]
 
 - Fix bug that occurred when downsampling cubes with more than 2048 elements
-  in one or more dimensions. [#277]
+  in one or more dimensions. [https://github.com/glue-viz/glue-vispy-viewers/pull/277]
 
-0.8 (2017-08-22)
-----------------
+## [0.8](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.7.2...v0.8) - 2017-08-22
 
-- Update viewer code to use non-Qt-specific combo helpers. [#266]
+### What's Changed
 
-- Fix compatibility of floodfill selection with recent Numpy versions. [#257, #267]
+#### New Features
 
-- Avoid errors when lower and upper limits in viewer options are equal. [#268]
+- Update viewer code to use non-Qt-specific combo helpers. [https://github.com/glue-viz/glue-vispy-viewers/pull/266]
 
-- Fix bug that caused the color of scatter plots to not always update. [#265]
+- Added a home button that resets the view. [https://github.com/glue-viz/glue-vispy-viewers/pull/254]
 
-- Fix color and size encoding when using the data clip option. [#261]
+#### Bug Fixes
 
-- Added a home button that resets the view. [#254]
+- Fix compatibility of floodfill selection with recent Numpy versions. [https://github.com/glue-viz/glue-vispy-viewers/pull/257, https://github.com/glue-viz/glue-vispy-viewers/pull/267]
 
-0.7.2 (2017-03-16)
-------------------
+- Avoid errors when lower and upper limits in viewer options are equal. [https://github.com/glue-viz/glue-vispy-viewers/pull/268]
+
+- Fix bug that caused the color of scatter plots to not always update. [https://github.com/glue-viz/glue-vispy-viewers/pull/265]
+
+- Fix color and size encoding when using the data clip option. [https://github.com/glue-viz/glue-vispy-viewers/pull/261]
+
+## [0.7.2](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.7...v0.7.2) - 2017-03-16
+
+#### Bug Fixes
 
 - Fixed bug that caused session files saved after removing subsets
-  to no longer be loadable. [#253]
+  to no longer be loadable. [https://github.com/glue-viz/glue-vispy-viewers/pull/253]
 
 - Fixed bug that caused record icon to appear multiple times when
-  successively creating 3D viewers. [#252]
+  successively creating 3D viewers. [https://github.com/glue-viz/glue-vispy-viewers/pull/252]
 
 - Fixed bug with volume rendering on Windows with Python 2.7, due to
-  Numpy .shape returning long integers. [#245]
+  Numpy .shape returning long integers. [https://github.com/glue-viz/glue-vispy-viewers/pull/245]
 
 - Fixed bug that caused the flipping of size and cmap limits in the
-  3D viewers to not work properly. [#251]
+  3D viewers to not work properly. [https://github.com/glue-viz/glue-vispy-viewers/pull/251]
 
 0.7.1 (unreleased)
-------------------
 
-- Fixed bugs with 3D selections following refactoring. [#243]
+#### Bug Fixes
 
-- Fixed the case where vmin == vmax for size or color. [#243]
+- Fixed bugs with 3D selections following refactoring. [https://github.com/glue-viz/glue-vispy-viewers/pull/243]
 
-0.7 (2017-02-15)
-----------------
+- Fixed the case where vmin == vmax for size or color. [https://github.com/glue-viz/glue-vispy-viewers/pull/243]
+
+## [0.7](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.6...v0.7) - 2017-02-15
+
+### What's Changed
+
+#### New Features
 
 - When multiple datasets are visible in a 3D view, selections now apply to
   all of them (except for point and point and drag selections, for which the
-  selection applies to the currently selected layer). [#208]
+  selection applies to the currently selected layer). [https://github.com/glue-viz/glue-vispy-viewers/pull/208]
+
+- Refactored the viewers to simplify the code and make development easier. [https://github.com/glue-viz/glue-vispy-viewers/pull/238]
+
+- Improve the default level selection for the isosurface viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/238]
+
+#### Other Changes
 
 - The selection tools have been refactored to use the new toolbar/tool
-  infrastructure in glue. [#208]
+  infrastructure in glue. [https://github.com/glue-viz/glue-vispy-viewers/pull/208]
 
-- Update all layers in 3D viewers if numerical values change in any datasaet. [#236]
+- Update all layers in 3D viewers if numerical values change in any datasaet. [https://github.com/glue-viz/glue-vispy-viewers/pull/236]
 
-- Refactored the viewers to simplify the code and make development easier. [#238]
+## [0.6](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.5...v0.6) - 2016-11-03
 
-- Improve the default level selection for the isosurface viewer. [#238]
-
-0.6 (2016-11-03)
-----------------
+#### Bug Fixes
 
 - Fixed a bug that caused subsets to not be added to viewers when adding a
-  dataset with already existing subsets. [#218]
+  dataset with already existing subsets. [https://github.com/glue-viz/glue-vispy-viewers/pull/218]
 
-- Fixed compatibility with Qt5. [#212]
+- Fixed compatibility with Qt5. [https://github.com/glue-viz/glue-vispy-viewers/pull/212]
 
 - Fixed a bug that caused session files created previously to not be
-  openable. [#213, #214]
+  openable. [https://github.com/glue-viz/glue-vispy-viewers/pull/213, https://github.com/glue-viz/glue-vispy-viewers/pull/214]
 
-- Fixed a bug that caused 3D selections to not work properly. [#219]
+- Fixed a bug that caused 3D selections to not work properly. [https://github.com/glue-viz/glue-vispy-viewers/pull/219]
 
-0.5 (2016-10-10)
-----------------
+## [0.5](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.4...v0.5) - 2016-10-10
 
-- Fixed a bug that caused alpha scaling to not work correctly when mapping
-  scatter marker colors to an attribute. [#201]
+### What's Changed
 
-- Watch for ``NumericalDataChangedMessage`` messages. [#183, #184]
+#### New Features
 
-- Fixed a bug that caused color-coding and size-scaling of points in 3D viewer
-  to not work for negative values. [#182, #185]
+- Watch for ``NumericalDataChangedMessage`` messages. [https://github.com/glue-viz/glue-vispy-viewers/pull/183, https://github.com/glue-viz/glue-vispy-viewers/pull/184]
 
-- Add support for overplotting scatter markers on top of volumes. [#200]
+- Add support for overplotting scatter markers on top of volumes. [https://github.com/glue-viz/glue-vispy-viewers/pull/200]
 
-- Add support for n-dimensional components in 3D scatter plot viewer. [#158]
+- Add support for n-dimensional components in 3D scatter plot viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/158]
 
 - Factor of ~10 improvement in performance when selecting data in the scatter
-  or volume viewers. [#165]
+  or volume viewers. [https://github.com/glue-viz/glue-vispy-viewers/pull/165]
 
-- Make selection frame wider. [#161]
+- Make selection frame wider. [https://github.com/glue-viz/glue-vispy-viewers/pull/161]
 
-- Small fix of the camera initial settings & rotate speed . [#154]
+- Small fix of the camera initial settings & rotate speed . [https://github.com/glue-viz/glue-vispy-viewers/pull/154]
 
-- Advanced point-mode selection for scatter points. [#160]
+- Advanced point-mode selection for scatter points. [https://github.com/glue-viz/glue-vispy-viewers/pull/160]
 
-- Experimental point-mode selection for volume viewer. [#159]
+- Experimental point-mode selection for volume viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/159]
 
-- Fix button to record animations when the user cancels the file save dialog.
-  [#186]
-
-- Fix Qt imports to use QtPy for new versions of glue. [#173, #178, #186]
-
-- Add an option to clip any data outside the specified limits. [#203]
+- Add an option to clip any data outside the specified limits. [https://github.com/glue-viz/glue-vispy-viewers/pull/203]
 
 - Add a checkbox to force the aspect ratio to be native instead of
-  making all axes the same length. [#205]
+  making all axes the same length. [https://github.com/glue-viz/glue-vispy-viewers/pull/205]
 
-0.4 (2016-05-24)
-----------------
+#### Bug Fixes
 
-- Bundle the latest developer version of VisPy. [#143, #144]
+- Fixed a bug that caused alpha scaling to not work correctly when mapping
+  scatter marker colors to an attribute. [https://github.com/glue-viz/glue-vispy-viewers/pull/201]
 
-- Add a checkbox to toggle between near and far-field view. [#140]
+- Fixed a bug that caused color-coding and size-scaling of points in 3D viewer
+  to not work for negative values. [https://github.com/glue-viz/glue-vispy-viewers/pull/182, https://github.com/glue-viz/glue-vispy-viewers/pull/185]
 
-- Support the options in Glue v0.8 for foreground and background colors in viewers. [#149]
+- Fix button to record animations when the user cancels the file save dialog.
+  [https://github.com/glue-viz/glue-vispy-viewers/pull/186]
+
+- Fix Qt imports to use QtPy for new versions of glue. [https://github.com/glue-viz/glue-vispy-viewers/pull/173, https://github.com/glue-viz/glue-vispy-viewers/pull/178, https://github.com/glue-viz/glue-vispy-viewers/pull/186]
+
+## [0.4](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.3...v0.4) - 2016-05-24
+
+- Add a checkbox to toggle between near and far-field view. [https://github.com/glue-viz/glue-vispy-viewers/pull/140]
+
+- Support the options in Glue v0.8 for foreground and background colors in viewers. [https://github.com/glue-viz/glue-vispy-viewers/pull/149]
+
+#### Bug Fixes
 
 - Fix a bug that caused subsets selected in the 3D viewers to be applied to
-  datasets for which they aren't relevant. [#151]
+  datasets for which they aren't relevant. [https://github.com/glue-viz/glue-vispy-viewers/pull/151]
 
-0.3 (2016-05-04)
-----------------
+#### Other Changes
 
-- Add selection toolbar and icons for 3D viewers. [#88, #92]
+- Bundle the latest developer version of VisPy. [https://github.com/glue-viz/glue-vispy-viewers/pull/143, https://github.com/glue-viz/glue-vispy-viewers/pull/144]
+
+## [0.3](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.2...v0.3) - 2016-05-04
+
+### What's Changed
+
+#### New Features
+
+- Add selection toolbar and icons for 3D viewers. [https://github.com/glue-viz/glue-vispy-viewers/pull/88, https://github.com/glue-viz/glue-vispy-viewers/pull/92]
+
+- Implemented 3D selection. [https://github.com/glue-viz/glue-vispy-viewers/pull/103]
+
+- Optimize the layout of options for the layer style editors to save space. [https://github.com/glue-viz/glue-vispy-viewers/pull/120]
+
+- Added the ability to save static images of the 3D viewers. [https://github.com/glue-viz/glue-vispy-viewers/pull/125]
+
+- Add toolbar icon to continuously rotate the view. [https://github.com/glue-viz/glue-vispy-viewers/pull/128][https://github.com/glue-viz/glue-vispy-viewers/pull/137]
+
+- Implement support for saving 3D viewers in session files. [https://github.com/glue-viz/glue-vispy-viewers/pull/130]
+
+- Added ``BACKGROUND_COLOR`` and ``FOREGROUND_COLOR`` settings at root of package. [https://github.com/glue-viz/glue-vispy-viewers/pull/134]
+
+- Save animation with imageio. [https://github.com/glue-viz/glue-vispy-viewers/pull/139]
+
+#### Bug Fixes
 
 - Workaround OpenGL issue that caused cubes with size > 2048 along any
-  dimension to not display. [#100]
+  dimension to not display. [https://github.com/glue-viz/glue-vispy-viewers/pull/100]
 
-- Implemented 3D selection. [#103]
-
-- Fix issue with _update_data on base VisPy viewer. [#106]
+- Fix issue with ``_update_data`` on base VisPy viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/106]
 
 - Make sure an error is raised if data is not 3-dimensional and shape doesn’t
-  agree with existing data in volume viewer. [#112]
+  agree with existing data in volume viewer. [https://github.com/glue-viz/glue-vispy-viewers/pull/112]
 
-- Fix a bug that caused exceptions when clearing/removing layer artists. [#117]
+- Fix a bug that caused exceptions when clearing/removing layer artists. [https://github.com/glue-viz/glue-vispy-viewers/pull/117]
 
-- Optimize the layout of options for the layer style editors to save space. [#120]
-
-- Added the ability to save static images of the 3D viewers. [#125]
-
-- Add toolbar icon to continuously rotate the view. [#128][#137]
-
-- Raise an explicit error if PyOpenGL is not installed. [#129]
-
-- Implement support for saving 3D viewers in session files. [#130]
+- Raise an explicit error if PyOpenGL is not installed. [https://github.com/glue-viz/glue-vispy-viewers/pull/129]
 
 - Fix bug that caused all layers in the 3D scatter viewer to disappear when
-  one layer was removed. [#131]
+  one layer was removed. [https://github.com/glue-viz/glue-vispy-viewers/pull/131]
 
-- Make sure the 3D viewer is updated if the zorder is set manually. [#132]
+- Make sure the 3D viewer is updated if the zorder is set manually. [https://github.com/glue-viz/glue-vispy-viewers/pull/132]
 
-- Added ``BACKGROUND_COLOR`` and ``FOREGROUND_COLOR`` settings at root of package. [#134]
+- Make sure combo boxes don't expand if component names are long. [https://github.com/glue-viz/glue-vispy-viewers/pull/135]
 
-- Make sure combo boxes don't expand if component names are long. [#135]
+#### Other Changes
 
-- Travis: add back testing against stable glue [#136]
+- Travis: add back testing against stable glue [https://github.com/glue-viz/glue-vispy-viewers/pull/136]
 
-- Save animation with imageio. [#139]
+- Add toggle for perspective view. [https://github.com/glue-viz/glue-vispy-viewers/pull/140]
 
-- Add toggle for perspective view. [#140]
-
-- Bundle latest developer version of Vispy. [#143] [#144]
+- Bundle latest developer version of Vispy. [https://github.com/glue-viz/glue-vispy-viewers/pull/143] [https://github.com/glue-viz/glue-vispy-viewers/pull/144]
 
 
+## [0.2](https://github.com/glue-viz/glue-vispy-viewers/compare/v0.1...v0.2) - 2015-03-11
 
-0.2 (2015-03-11)
-----------------
+### What's Changed
+
+#### New Features
 
 - Significant work has gone into making the scatter and volume viewers
   functional. Subsets can be highlighted in either viewer.
 
-0.1 (2015-10-19)
-----------------
+## [0.1](https://github.com/glue-vispy-viewers/glue/releases/tag/v0.1) - 2015-10-19
 
 - Initial release, includes simple volume viewer.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Glue plugin for 3D viewers using VisPy
 ======================================
 
-|Travis Status| |AppVeyor Status| |Coverage Status|
+|Actions Status| |Coverage Status|
 
 Requirements
 ------------
@@ -56,9 +56,8 @@ working directory::
     from glue_vispy_viewers.isosurface import setup as setup_isosurface
     setup_isosurface()
 
-.. |Travis Status| image:: https://travis-ci.org/glue-viz/glue-vispy-viewers.svg
-   :target: https://travis-ci.org/glue-viz/glue-vispy-viewers?branch=master
-.. |AppVeyor Status| image:: https://ci.appveyor.com/api/projects/status/7h9js5tdu9v9nnlg/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/glue-viz/glue-3d-viewer/branch/master
-.. |Coverage Status| image:: https://coveralls.io/repos/github/glue-viz/glue-vispy-viewers/badge.svg
-   :target: https://coveralls.io/github/glue-viz/glue-vispy-viewers
+.. |Actions Status| image:: https://github.com/glue-viz/glue-vispy-viewers/workflows/CI%20Workflows/badge.svg
+    :target: https://github.com/glue-viz/glue-vispy-viewers/actions
+    :alt: Glue's GitHub Actions CI Status
+.. |Coverage Status| image:: https://codecov.io/gh/glue-viz/glue-vispy-viewers/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/glue-viz/glue-vispy-viewers

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,11 @@
+How to release a new version of Glue-VisPy-Viewers
+==================================================
+
+#. Follow the instructions in the `Glue documentation
+   <http://docs.glueviz.org/en/stable/developer_guide/release.html>`_
+   to create a release using the `GitHub menu
+   <https://github.com/glue-viz/glue-vispy-viewers/releases/new>`_.
+
+#. Have a beverage of your choosing while you can check the build progress
+   `here <https://github.com/glue-viz/glue-vispy-viewers/actions/>`_.
+   (The wheels may take a little while to build).

--- a/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
+++ b/glue_vispy_viewers/isosurface/tests/test_isosurface_viewer.py
@@ -9,6 +9,7 @@ from glue.core.component import Component
 from ..isosurface_viewer import VispyIsosurfaceViewer
 
 IS_WIN = sys.platform == 'win32'
+PY_LT38 = sys.version_info < (3, 8)
 
 
 def make_test_data():
@@ -25,6 +26,7 @@ def make_test_data():
 
 
 @pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
+@pytest.mark.skipif('PY_LT38', reason='Teardown error on Python 3.7')
 def test_isosurface_viewer(tmpdir):
 
     # Create fake data

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -329,24 +329,7 @@ def test_scatter_remove_layer_artists(tmpdir):
     ga2.close()
 
 
-def test_add_data(tmpdir):
-
-    # Regression test for a bug that an error when adding a dataset with an
-    # incompatible subset to a 3D scatter viewer.
-
-    data1 = Data(label="Data 1", x=[1, 2, 3])
-    data2 = Data(label="Data 2", y=[4, 5, 6])
-
-    dc = DataCollection([data1, data2])
-    ga = GlueApplication(dc)
-    ga.show()
-
-    scatter = ga.new_data_viewer(VispyScatterViewer)
-    scatter.add_data(data1)
-
-    ga.close()
-
-
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_add_data_with_incompatible_subsets(tmpdir):
 
     # Regression test for a bug that an error when adding a dataset with an
@@ -369,6 +352,7 @@ def test_add_data_with_incompatible_subsets(tmpdir):
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_not_all_points_inside_limits(tmpdir):
 
     # Regression test for a bug that occurred when not all points were inside
@@ -392,6 +376,7 @@ def test_not_all_points_inside_limits(tmpdir):
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_categorical_color_size(tmpdir):
 
     # Create fake data
@@ -424,6 +409,7 @@ def test_categorical_color_size(tmpdir):
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_layer_visibility_after_session(tmpdir):
 
     # Regression test for a bug that caused layers to be incorrectly visible

--- a/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
+++ b/glue_vispy_viewers/scatter/tests/test_scatter_viewer.py
@@ -190,6 +190,7 @@ def test_error_bars(tmpdir):
     ga2.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_vectors(tmpdir):
 
     # Create fake data
@@ -254,6 +255,7 @@ def test_vectors(tmpdir):
     ga2.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_n_dimensional_data():
 
     # Create fake data
@@ -283,6 +285,7 @@ def test_n_dimensional_data():
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_scatter_remove_layer_artists(tmpdir):
 
     # Regression test for a bug that caused layer states to not be removed
@@ -324,6 +327,24 @@ def test_scatter_remove_layer_artists(tmpdir):
     ga2 = GlueApplication.restore_session(session_file)
     ga2.show()
     ga2.close()
+
+
+def test_add_data(tmpdir):
+
+    # Regression test for a bug that an error when adding a dataset with an
+    # incompatible subset to a 3D scatter viewer.
+
+    data1 = Data(label="Data 1", x=[1, 2, 3])
+    data2 = Data(label="Data 2", y=[4, 5, 6])
+
+    dc = DataCollection([data1, data2])
+    ga = GlueApplication(dc)
+    ga.show()
+
+    scatter = ga.new_data_viewer(VispyScatterViewer)
+    scatter.add_data(data1)
+
+    ga.close()
 
 
 def test_add_data_with_incompatible_subsets(tmpdir):

--- a/glue_vispy_viewers/volume/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/tests/test_volume_viewer.py
@@ -1,3 +1,5 @@
+import sys
+import pytest
 import numpy as np
 
 from glue.core import DataCollection, Data
@@ -7,6 +9,8 @@ from glue.core.link_helpers import LinkSame
 from glue.core.fixed_resolution_buffer import PIXEL_CACHE, ARRAY_CACHE
 
 from ..volume_viewer import VispyVolumeViewer
+
+IS_WIN = sys.platform == 'win32'
 
 
 def teardown_function(function):
@@ -30,6 +34,7 @@ def make_test_data(dimensions=(10, 10, 10)):
     return data
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_volume_viewer(tmpdir):
 
     # Create fake data
@@ -108,6 +113,7 @@ def test_volume_viewer(tmpdir):
     ga2.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_array_shape(tmpdir):
     # Create irregularly shaped data cube
     data = make_test_data((3841, 48, 46))
@@ -130,6 +136,7 @@ def test_array_shape(tmpdir):
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_scatter_on_volume(tmpdir):
 
     data1 = Data(a=np.arange(60).reshape((3, 4, 5)))
@@ -168,6 +175,7 @@ def test_scatter_on_volume(tmpdir):
     ga2.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_layer_visibility_clip():
 
     # Regression test for a bug that meant that updating the clip data setting
@@ -201,6 +209,7 @@ def test_layer_visibility_clip():
     ga.close()
 
 
+@pytest.mark.skipif('IS_WIN', reason='Windows fatal exception: access violation')
 def test_remove_subset_group():
 
     # Regression test for a bug that meant that removing a subset caused an
@@ -240,6 +249,8 @@ def test_add_data_with_incompatible_subsets(tmpdir):
     # for data1
     dc.new_subset_group(subset_state=data2.id['y'] > 0.5, label='subset 1')
 
+    if IS_WIN:
+        pytest.skip(reason='Windows fatal exception: access violation')
     volume = ga.new_data_viewer(VispyVolumeViewer)
     volume.add_data(data1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
 changedir =
     test: .tmp/{envname}
 deps =
-    PyQt5==5.14
+    PyQt5==5.15.*
     dev: glue-core @ git+https://github.com/glue-viz/glue
     dev: vispy @ git+https://github.com/vispy/vispy
 extras =


### PR DESCRIPTION
## Description
Adding workflow and configuration for updating changelog automatically from PR titles and labels, using GH actions.

The next release action would thus create entries for these PRs (+ any to come until then), to be verified:

```
- Update API to support `echo>=0.6` and `vispy=0.11`. [#373]
```
Labels for `documentation`, `no-changelog-entry-needed` (+`skip-changelog`) have yet to be added.
Detailed instructions are linking to http://docs.glueviz.org/en/stable/developer_guide/release.html, which will become live after the next glue-core release.