### PR TITLE
Drop Python 3.7 and fix compatibility with latest glue-core versions

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,10 +34,10 @@ jobs:
 
       envs: |
         # Standard tests
-        - linux: py37-test
         - linux: py38-test
-        - linux: py39-test-pyqt6
-        - linux: py310-test-dev-pyqt6
+        - linux: py39-test
+        - linux: py310-test-pyqt6
+        - linux: py311-test-dev-pyqt6
 
         - macos: py38-test
         - macos: py39-test-dev

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -1,11 +1,12 @@
 import uuid
 import weakref
 
+import numpy as np
+
 from matplotlib.colors import ColorConverter
 
 from glue.core.data import Subset, Data
 from glue.core.exceptions import IncompatibleAttribute
-from glue.utils import broadcast_to
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from .colors import get_translucent_cmap
 from .layer_state import VolumeLayerState
@@ -45,7 +46,7 @@ class DataProxy(object):
         shape = [bound[2] for bound in bounds]
 
         if self.layer_artist is None or self.viewer_state is None:
-            return broadcast_to(0, shape)
+            return np.broadcast_to(0, shape)
 
         if isinstance(self.layer_artist.layer, Subset):
             try:
@@ -56,7 +57,7 @@ class DataProxy(object):
                     cache_id=self.layer_artist.id)
             except IncompatibleAttribute:
                 self.layer_artist.disable_incompatible_subset()
-                return broadcast_to(0, shape)
+                return np.broadcast_to(0, shape)
             else:
                 self.layer_artist.enable()
         else:
@@ -67,7 +68,7 @@ class DataProxy(object):
                     cache_id=self.layer_artist.id)
             except IncompatibleAttribute:
                 self.layer_artist.disable('Layer data is not fully linked to reference data')
-                return broadcast_to(0, shape)
+                return np.broadcast_to(0, shape)
             else:
                 self.layer_artist.enable()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     pillow
     matplotlib
     vispy>=0.9.1
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 glue.plugins =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{test}-{dev}{,-pyqt6}
+    py{38,39,310,311}-{test}-{dev}{,-pyqt6}
     codestyle
 requires = pip >= 18.0
            setuptools >= 30.3.0


### PR DESCRIPTION
In particular we were importing broadcast_to from glue which has now been removed.