### PR TITLE
Added oldestdeps tox configuration and enable in CI, and bump minimum version of vispy to 0.12

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -35,20 +35,20 @@ jobs:
       envs: |
         # Tests without Qt. For now glfw can't run on MacOS runners in headless mode
         # so we only run on Linux and Windows.
-        - linux: py38-test
+        - linux: py38-test-oldestdeps
         - windows: py39-test
         - linux: py310-test
         - windows: py311-test
         - linux: py311-test-dev
 
         # Tests with Jupyter
-        - linux: py38-test-jupyter
+        - linux: py38-test-jupyter-oldestdeps
         - windows: py39-test-jupyter
         - linux: py310-test-jupyter
         - windows: py311-test-jupyter
 
         # Tests with Qt
-        - linux: py38-test-pyqt63
+        - linux: py38-test-pyqt63-oldestdeps
         - linux: py39-test-pyside63
         - linux: py310-test-pyqt64
         - linux: py311-test-dev-pyqt64

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     echo>=0.6
     scipy
     matplotlib
-    vispy>=0.9.1
+    vispy>=0.12.0
     importlib_metadata>=3.6; python_version<'3.10'
     glfw
     imageio

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,9 @@ deps =
     pyside64: PySide6==6.4.*
     dev: glue-core @ git+https://github.com/glue-viz/glue
     dev: vispy @ git+https://github.com/vispy/vispy
+    oldestdeps: glue-core==1.13.*
+    oldestdeps: echo==0.6
+    oldestdeps: vispy==0.9.*
 extras =
     test: test
     pyqt63,pyqt64: pyqt

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     dev: vispy @ git+https://github.com/vispy/vispy
     oldestdeps: glue-core==1.13.*
     oldestdeps: echo==0.6
-    oldestdeps: vispy==0.9.*
+    oldestdeps: vispy==0.12.*
 extras =
     test: test
     pyqt63,pyqt64: pyqt


### PR DESCRIPTION
Just to make sure we are compatible with the oldest declared dependencies.