### PR TITLE
Choose correct style widget for scatter layers in Jupyter volume viewer

### DIFF
--- a/glue_vispy_viewers/volume/jupyter/tests/test_viewer.py
+++ b/glue_vispy_viewers/volume/jupyter/tests/test_viewer.py
@@ -2,6 +2,8 @@ import numpy as np
 from glue.core import Data
 from glue_jupyter import jglue
 from ..volume_viewer import JupyterVispyVolumeViewer
+from ....scatter.jupyter.layer_state_widget import Scatter3DLayerStateWidget
+from ..layer_state_widget import Volume3DLayerStateWidget
 
 
 def test_basic_jupyter_volume():
@@ -9,3 +11,23 @@ def test_basic_jupyter_volume():
     data = Data(x=np.arange(24).reshape((2, 3, 4)), label="cube data")
     app.add_data(data)
     app.new_data_viewer(JupyterVispyVolumeViewer, data=data)
+
+
+def test_jupyter_layer_widgets():
+    app = jglue()
+    volume_data = Data(x=np.arange(24).reshape((2, 3, 4)), label="cube data")
+    scatter_data = Data(x=np.arange(0, 5), y=np.arange(5, 10), z=np.arange(20, 25))
+    for index, component in enumerate(("x", "y", "z")):
+        app.add_link(volume_data, f"Pixel Axis {2-index} [{component}]", scatter_data, component)
+    app.add_data(volume_data)
+    app.add_data(scatter_data)
+    viewer = app.new_data_viewer(JupyterVispyVolumeViewer, data=volume_data)
+    viewer.add_data(scatter_data)
+
+    layer_options = viewer.layer_options
+    volume_layer = viewer.layers[0]
+    scatter_layer = viewer.layers[1]
+    volume_widget = layer_options.layer_to_dict(volume_layer, 0)["layer_panel"]
+    assert isinstance(volume_widget, Volume3DLayerStateWidget)
+    scatter_widget = layer_options.layer_to_dict(scatter_layer, 1)["layer_panel"]
+    assert isinstance(scatter_widget, Scatter3DLayerStateWidget)

--- a/glue_vispy_viewers/volume/jupyter/volume_viewer.py
+++ b/glue_vispy_viewers/volume/jupyter/volume_viewer.py
@@ -1,8 +1,12 @@
 import os
 
 from glue_jupyter.view import IPyWidgetView
+
+from ...scatter.layer_artist import ScatterLayerArtist
+from ..layer_artist import VolumeLayerArtist
 from ..volume_viewer import VispyVolumeViewerMixin
 from .viewer_state_widget import Volume3DViewerStateWidget
+from ...scatter.jupyter.layer_state_widget import Scatter3DLayerStateWidget
 from .layer_state_widget import Volume3DLayerStateWidget
 from ...common.jupyter.toolbar import VispyJupyterToolbar
 
@@ -12,8 +16,9 @@ __all__ = ['JupyterVispyVolumeViewer']
 class JupyterVispyVolumeViewer(VispyVolumeViewerMixin, IPyWidgetView):
 
     _options_cls = Volume3DViewerStateWidget
-    _layer_style_widget_cls = Volume3DLayerStateWidget
     _toolbar_cls = VispyJupyterToolbar
+    _layer_style_widget_cls = {VolumeLayerArtist: Volume3DLayerStateWidget,
+                               ScatterLayerArtist: Scatter3DLayerStateWidget}
 
     def __init__(self, *args, **kwargs):
         # Vispy and jupyter_rfb don't work correctly on Linux unless DISPLAY is set


### PR DESCRIPTION
Azmé and I noticed that the Jupyter volume viewer will give an error if one tries to add a scatter layer, due to the fact that the Jupyter viewer only has the volume layer style widget registered. This PR updates the Jupyter viewer so that the application can choose the correct widget for scatter layers.