### PR TITLE
Allow view to keep rotating while other tools are used

### DIFF
--- a/glue_vispy_viewers/common/qt/tests/test_vispy_toolbar.py
+++ b/glue_vispy_viewers/common/qt/tests/test_vispy_toolbar.py
@@ -56,11 +56,11 @@ def test_rotate(capsys):
     app = GlueApplication()
     viewer = app.new_data_viewer(VispyScatterViewer)
 
-    viewer.toolbar.actions['vispy:rotate'].toggle()
-    assert viewer.toolbar.active_tool.tool_id == 'vispy:rotate'
+    viewer.toolbar.actions['vispy:rotate'].trigger()
+    assert viewer.toolbar.tools['vispy:rotate'].rotating
 
-    viewer.toolbar.actions['vispy:rotate'].toggle()
-    assert viewer.toolbar.active_tool is None
+    viewer.toolbar.actions['vispy:rotate'].trigger()
+    assert not viewer.toolbar.tools['vispy:rotate'].rotating
 
     out, err = capsys.readouterr()
     assert out.strip() == ""

--- a/glue_vispy_viewers/common/qt/tests/test_vispy_toolbar.py
+++ b/glue_vispy_viewers/common/qt/tests/test_vispy_toolbar.py
@@ -50,7 +50,6 @@ def test_save(tmpdir, capsys):
     app.close()
 
 
-@pytest.mark.skipif('not IS_WIN', reason='Teardown disaster')
 def test_rotate(capsys):
 
     app = GlueApplication()

--- a/glue_vispy_viewers/common/tools.py
+++ b/glue_vispy_viewers/common/tools.py
@@ -1,6 +1,6 @@
 import os
 
-from glue.viewers.common.tool import Tool, CheckableTool
+from glue.viewers.common.tool import Tool
 
 from glue.config import viewer_tool
 
@@ -25,7 +25,7 @@ class ResetTool(Tool):
 
 
 @viewer_tool
-class RotateTool(CheckableTool):
+class RotateTool(Tool):
 
     icon = ROTATE_ICON
     tool_id = 'vispy:rotate'
@@ -33,14 +33,16 @@ class RotateTool(CheckableTool):
     tool_tip = 'Start/Stop rotation'
 
     timer = None
+    rotating = False
 
     def activate(self):
         if self.timer is None:
             self.timer = app.Timer(connect=self.rotate)
-        self.timer.start(0.1)
-
-    def deactivate(self):
-        self.timer.stop()
+        self.rotating = not self.rotating
+        if self.rotating:
+            self.timer.start(0.1)
+        else:
+            self.timer.stop()
 
     def rotate(self, event):
         self.viewer._vispy_widget.view.camera.azimuth -= 1.  # set speed as constant first

--- a/glue_vispy_viewers/volume/qt/tests/test_volume_toolbar.py
+++ b/glue_vispy_viewers/volume/qt/tests/test_volume_toolbar.py
@@ -35,11 +35,11 @@ def test_volumeviewer_toolbar():
     toolbar = v.toolbar
 
     # test rotate tool
-    toolbar.actions['vispy:rotate'].toggle()
-    assert toolbar.active_tool.tool_id == 'vispy:rotate'
-    # TODO: assert a mode here
-    toolbar.actions['vispy:rotate'].toggle()
-    assert toolbar.active_tool is None
+    toolbar.actions['vispy:rotate'].trigger()
+    assert toolbar.tools['vispy:rotate'].rotating
+
+    toolbar.actions['vispy:rotate'].trigger()
+    assert not toolbar.tools['vispy:rotate'].rotating
 
     # test lasso selection tool
     toolbar.actions['vispy:lasso'].toggle()

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     pyqt69: PyQt6==6.9.*
     pyside69: PySide6==6.9.*
     dev: glue-core @ git+https://github.com/glue-viz/glue
+    dev: glue-qt @ git+https://github.com/glue-viz/glue-qt
     dev: vispy @ git+https://github.com/vispy/vispy
     oldestdeps: glue-core==1.13.*
     oldestdeps: echo==0.6


### PR DESCRIPTION
This PR resolves #334. I think the most straightforward way to do this is to have the rotation tool not be a `CheckableTool`, but instead just be a `Tool` which internally tracks whether it's currently rotating or not. We also got a [request](https://github.com/glue-viz/glue/issues/2504) for this functionality recently.

Since this a frontend-agnostic tool, there isn't way to do something like update the icon without creating frontend-specific subclasses, which feels like overkill to me when the tooltip pretty clearly states the button function.