### PR TITLE
Delay updates to multiscatter if _update_scatter is called without update being called first

### DIFF
--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -315,32 +315,33 @@ class ScatterLayerArtist(VispyLayerArtist):
         self._last_viewer_state.update(self._viewer_state.as_dict())
         self._last_layer_state.update(self.state.as_dict())
 
-        if force or len(changed & DATA_PROPERTIES) > 0:
-            self._update_data()
-            force = True
+        with self._multiscat.delay_update():
 
-        if force or len(changed & SIZE_PROPERTIES) > 0:
-            self._update_sizes()
+            if force or len(changed & DATA_PROPERTIES) > 0:
+                self._update_data()
+                force = True
 
-        if force or len(changed & ERROR_PROPERTIES) > 0:
-            self._update_errors()
+            if force or len(changed & SIZE_PROPERTIES) > 0:
+                self._update_sizes()
 
-        if force or len(changed & VECTOR_PROPERTIES) > 0:
-            self._update_vectors()
+            if force or len(changed & ERROR_PROPERTIES) > 0:
+                self._update_errors()
 
-        if force or len(changed & COLOR_PROPERTIES) > 0:
-            self._update_colors()
+            if force or len(changed & VECTOR_PROPERTIES) > 0:
+                self._update_vectors()
 
-        if force or len(changed & ALPHA_PROPERTIES) > 0:
-            self._update_alpha()
+            if force or len(changed & COLOR_PROPERTIES) > 0:
+                self._update_colors()
 
-        if force or len(changed & VISIBLE_PROPERTIES) > 0:
-            self._update_visibility()
+            if force or len(changed & ALPHA_PROPERTIES) > 0:
+                self._update_alpha()
 
-        if force or len(changed & ARROW_PROPERTIES) > 0:
-            self._update_arrow_head()
+            if force or len(changed & VISIBLE_PROPERTIES) > 0:
+                self._update_visibility()
+
+            if force or len(changed & ARROW_PROPERTIES) > 0:
+                self._update_arrow_head()
 
     def update(self):
-        with self._multiscat.delay_update():
-            self._update_scatter(force=True)
+        self._update_scatter(force=True)
         self.redraw()

--- a/glue_vispy_viewers/scatter/multi_scatter.py
+++ b/glue_vispy_viewers/scatter/multi_scatter.py
@@ -19,14 +19,18 @@ class MultiColorScatter(scene.visuals.Markers):
         self.layers = {}
         self._combined_data = None
         self._skip_update = False
+        self._update_called = False
         self._error_vector_widget = None
         super(MultiColorScatter, self).__init__(*args, **kwargs)
 
     @contextmanager
     def delay_update(self):
         self._skip_update = True
+        self._update_called = False
         yield
         self._skip_update = False
+        if self._update_called:
+            self._update()
 
     def allocate(self, label):
         if label in self.layers:
@@ -102,6 +106,7 @@ class MultiColorScatter(scene.visuals.Markers):
     def _update(self):
 
         if self._skip_update:
+            self._update_called = True
             return
 
         data = []


### PR DESCRIPTION
I noticed some performance issues when restoring sessions with large 3D scatter plots, due to repeated calls to ``_update``. This speeds things up a bit!