### PR TITLE
Allow displaying scatter points outside of bounding box

### DIFF
--- a/glue_vispy_viewers/common/qt/viewer_options.py
+++ b/glue_vispy_viewers/common/qt/viewer_options.py
@@ -6,6 +6,8 @@ from echo.qt import autoconnect_callbacks_to_qt
 
 from glue_qt.utils import load_ui
 
+from glue_vispy_viewers.scatter.viewer_state import Vispy3DScatterViewerState
+
 __all__ = ["VispyOptionsWidget"]
 
 
@@ -26,6 +28,9 @@ class VispyOptionsWidget(QtWidgets.QWidget):
                           'valuetext_x_stretch': dict(fmt='{:6.2f}'),
                           'valuetext_y_stretch': dict(fmt='{:6.2f}'),
                           'valuetext_z_stretch': dict(fmt='{:6.2f}')}
+
+        if not isinstance(viewer_state, Vispy3DScatterViewerState):
+            self.ui.bool_clip_data.hide()
 
         if not hasattr(viewer_state, 'downsample'):
             self.ui.bool_downsample.hide()

--- a/glue_vispy_viewers/common/qt/viewer_options.ui
+++ b/glue_vispy_viewers/common/qt/viewer_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>276</width>
-    <height>390</height>
+    <height>415</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,7 +33,6 @@
     <widget class="QLabel" name="label_resolution">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -60,7 +59,6 @@
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,7 +74,6 @@
     <widget class="QLabel" name="label_reference_data">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -92,7 +89,6 @@
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -161,16 +157,6 @@
    </item>
    <item row="12" column="2" colspan="4">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="bool_perspective_view">
-       <property name="text">
-        <string>Perspective</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0" colspan="2">
       <widget class="QCheckBox" name="bool_downsample">
        <property name="enabled">
@@ -184,6 +170,13 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="bool_native_aspect">
+       <property name="text">
+        <string>Native aspect ratio</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1">
       <widget class="QCheckBox" name="bool_visible_axes">
        <property name="text">
@@ -194,10 +187,13 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="bool_native_aspect">
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="bool_perspective_view">
        <property name="text">
-        <string>Native aspect ratio</string>
+        <string>Perspective</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -231,6 +227,13 @@
        </item>
       </layout>
      </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="bool_clip_data">
+       <property name="text">
+        <string>Restrict to bounding box</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="0" column="3" colspan="3">
@@ -258,7 +261,6 @@
     <widget class="QLabel" name="x_lab">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>

--- a/glue_vispy_viewers/scatter/layer_artist.py
+++ b/glue_vispy_viewers/scatter/layer_artist.py
@@ -190,6 +190,7 @@ class ScatterLayerArtist(VispyLayerArtist):
         self._multiscat.set_data_values(self.id, x, y, z)
 
         # Mask points outside the clip limits
+        self._clip_limits = self._viewer_state.clip_limits if self._viewer_state.clip_data else None
         if self._clip_limits is None:
             self._multiscat.set_mask(self.id, None)
         else:


### PR DESCRIPTION
Fixes #338. I had actually set this up a while back but never submitted the PR for some reason; here it is on top of the current branch.

Since `clip_data` is defined on the base viewer state, I couldn't use the same `hasattr` approach to hide the checkbox for the volume viewer, so I just did an explicit class check instead. Not my favorite thing but it works.