### PR TITLE
Support colormaps in volume viewer

### DIFF
--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -7,7 +7,7 @@ def create_cmap_template(n):
         "vec4 translucent_colormap(float t) {",
     ]
     for i in range(n-1):
-        lines.append(f"    if (t <= {i / n})")
+        lines.append(f"    if (t <= {(i+1) / n})")
         lines.append(f"        {{ return $color_{i}; }}")
     lines.append(f"    return $color_{n-1};")
     lines.append("}")

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,4 +1,18 @@
+from matplotlib import colormaps
 from vispy.color import BaseColormap
+
+
+def create_cmap_template(n):
+    lines = [
+        "vec4 translucent_colormap(float t) {",
+    ]
+    for i in range(n-1):
+        lines.append(f"    if (t < {i / n})")
+        lines.append(f"        {{ return $color_{i}; }}")
+    lines.append(f"    return $color_{n-1};")
+    lines.append("}")
+
+    return "\n".join(lines)
 
 
 def get_translucent_cmap(r, g, b):
@@ -18,10 +32,32 @@ def get_linear_cmap(cl, ch):
     class LinearCmap(BaseColormap):
         c = tuple(f"{l} + t * ({h} - {l})" for l, h in zip(cl, ch))
         glsl_map = """
-        vec4 translucent_fire(float t) {{
+        vec4 translucent_linear(float t) {{
             return vec4({0}, {1}, {2}, t);
         }}
         """.format(*c)
 
     return LinearCmap()
+
+
+def get_mpl_cmap(cmap_name):
+    
+    cmap = colormaps[cmap_name]
+    colors = cmap.colors
+    n_colors = len(colors)
+    colors = [color + [index / n_colors] for index, color in enumerate(colors)]
+    template = create_cmap_template(n_colors)
+    print(template)
+
+    class MatplotlibCmap(BaseColormap):
+        glsl_map = template
+        # glsl_map = """
+        # vec4 test(float t) {
+        #     if (t < 0.5) { return $color_0; }
+        #     return $color_200;
+        # }
+        # """
+
+    return MatplotlibCmap(colors=colors)
+
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -35,7 +35,7 @@ def get_mpl_cmap(cmap):
         colors = [color + [index / n_colors] for index, color in enumerate(colors)]
     else:
         n_colors = 256
-        colors = [cmap(index / n_colors) for index in range(n_colors)]
+        colors = [cmap(index / n_colors)[:3] + (index / n_colors,) for index in range(n_colors)]
 
     template = create_cmap_template(n_colors)
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -7,7 +7,7 @@ def create_cmap_template(n):
         "vec4 translucent_colormap(float t) {",
     ]
     for i in range(n-1):
-        lines.append(f"    if (t < {i / n})")
+        lines.append(f"    if (t <= {i / n})")
         lines.append(f"        {{ return $color_{i}; }}")
     lines.append(f"    return $color_{n-1};")
     lines.append("}")

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,5 +1,4 @@
-from matplotlib import colormaps
-from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+from matplotlib.colors import ListedColormap
 from vispy.color import BaseColormap
 
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -11,3 +11,17 @@ def get_translucent_cmap(r, g, b):
         """.format(r, g, b)
 
     return TranslucentCmap()
+
+
+def get_linear_cmap(cl, ch):
+
+    class LinearCmap(BaseColormap):
+        c = tuple(f"{l} + t * ({h} - {l})" for l, h in zip(cl, ch))
+        glsl_map = """
+        vec4 translucent_fire(float t) {{
+            return vec4({0}, {1}, {2}, t);
+        }}
+        """.format(*c)
+
+    return LinearCmap()
+

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,4 +1,5 @@
 from matplotlib import colormaps
+from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from vispy.color import BaseColormap
 
 
@@ -27,37 +28,19 @@ def get_translucent_cmap(r, g, b):
     return TranslucentCmap()
 
 
-def get_linear_cmap(cl, ch):
+def get_mpl_cmap(cmap):
 
-    class LinearCmap(BaseColormap):
-        c = tuple(f"{l} + t * ({h} - {l})" for l, h in zip(cl, ch))
-        glsl_map = """
-        vec4 translucent_linear(float t) {{
-            return vec4({0}, {1}, {2}, t);
-        }}
-        """.format(*c)
+    if isinstance(cmap, ListedColormap):
+        colors = cmap.colors
+        n_colors = len(colors)
+        colors = [color + [index / n_colors] for index, color in enumerate(colors)]
+    else:
+        n_colors = 256
+        colors = [cmap(index / n_colors) for index in range(n_colors)]
 
-    return LinearCmap()
-
-
-def get_mpl_cmap(cmap_name):
-    
-    cmap = colormaps[cmap_name]
-    colors = cmap.colors
-    n_colors = len(colors)
-    colors = [color + [index / n_colors] for index, color in enumerate(colors)]
     template = create_cmap_template(n_colors)
-    print(template)
 
     class MatplotlibCmap(BaseColormap):
         glsl_map = template
-        # glsl_map = """
-        # vec4 test(float t) {
-        #     if (t < 0.5) { return $color_0; }
-        #     return $color_200;
-        # }
-        # """
 
     return MatplotlibCmap(colors=colors)
-
-

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
@@ -2,6 +2,7 @@ import ipyvuetify as v
 import traitlets
 
 from glue.config import colormaps
+from glue.core.subset import Subset
 
 from glue_jupyter.state_traitlets_helpers import GlueState
 from glue_jupyter.vuetify_helpers import link_glue_choices
@@ -25,11 +26,15 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
 
     cmap_items = traitlets.List().tag(sync=True)
 
+    subset = traitlets.Bool().tag(sync=True)
+
     def __init__(self, layer_state):
         super().__init__()
 
         self.layer_state = layer_state
         self.glue_state = layer_state
+
+        self.subset = isinstance(layer_state.layer, Subset)
 
         link_glue_choices(self, layer_state, "attribute")
         link_glue_choices(self, layer_state, "color_mode")

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
@@ -1,6 +1,8 @@
 import ipyvuetify as v
 import traitlets
 
+from glue.config import colormaps
+
 from glue_jupyter.state_traitlets_helpers import GlueState
 from glue_jupyter.vuetify_helpers import link_glue_choices
 
@@ -16,6 +18,13 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
     attribute_items = traitlets.List().tag(sync=True)
     attribute_selected = traitlets.Int(allow_none=True).tag(sync=True)
 
+    # Color
+
+    color_mode_items = traitlets.List().tag(sync=True)
+    color_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
+
+    cmap_items = traitlets.List().tag(sync=True)
+
     def __init__(self, layer_state):
         super().__init__()
 
@@ -23,3 +32,16 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
         self.glue_state = layer_state
 
         link_glue_choices(self, layer_state, "attribute")
+        link_glue_choices(self, layer_state, "color_mode")
+
+        self.cmap_items = [
+            {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
+        ]
+
+    def vue_set_colormap(self, data):
+        cmap = None
+        for member in colormaps.members:
+            if member[1].name == data:
+                cmap = member[1]
+                break
+        self.layer_state.cmap = cmap

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -4,12 +4,12 @@
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details class="margin-bottom: 16px" />
         </div>
         <template v-if="glue_state.color_mode === 'Linear'">
-          <div v-if="!subset">
+          <div>
               <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
           </div>
         </template>
         <template v-else>
-          <div>
+          <div v-if="!subset">
               <v-select label="color" :items="color_mode_items" v-model="color_mode_selected" hide-details />
           </div>
         </template>

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -4,7 +4,7 @@
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details class="margin-bottom: 16px" />
         </div>
         <template v-if="glue_state.color_mode === 'Linear'">
-          <div>
+          <div v-if="!subset">
               <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
           </div>
         </template>

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -3,6 +3,16 @@
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details class="margin-bottom: 16px" />
         </div>
+        <template v-if="glue_state.color_mode === 'Linear'">
+          <div>
+              <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
+          </div>
+        </template>
+        <template v-else>
+          <div>
+              <v-select label="color" :items="color_mode_items" v-model="color_mode_selected" hide-details />
+          </div>
+        </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
             <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -8,7 +8,7 @@ from matplotlib.colors import ColorConverter
 from glue.core.data import Subset, Data
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
-from .colors import get_translucent_cmap
+from .colors import get_linear_cmap, get_translucent_cmap
 from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
@@ -156,7 +156,9 @@ class VolumeLayerArtist(VispyLayerArtist):
         PIXEL_CACHE.pop(self.id, None)
 
     def _update_cmap_from_color(self):
-        cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
+        cmap = get_linear_cmap((0.5, 0, 0.5), (0.5, 0.5, 0))
+        # cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
+        print(ColorConverter().to_rgb(self.state.color))
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()
 

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -159,13 +159,10 @@ class VolumeLayerArtist(VispyLayerArtist):
         PIXEL_CACHE.pop(self.id, None)
 
     def _update_cmap(self):
-        print(self.state.cmap)
         if self.state.color_mode == "Fixed":
             cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
         else:
             cmap = get_mpl_cmap(self.state.cmap)
-
-        print(cmap)
 
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -8,7 +8,7 @@ from matplotlib.colors import ColorConverter
 from glue.core.data import Subset, Data
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
-from .colors import get_linear_cmap, get_translucent_cmap
+from .colors import get_linear_cmap, get_mpl_cmap, get_translucent_cmap
 from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
@@ -156,9 +156,10 @@ class VolumeLayerArtist(VispyLayerArtist):
         PIXEL_CACHE.pop(self.id, None)
 
     def _update_cmap_from_color(self):
-        cmap = get_linear_cmap((0.5, 0, 0.5), (0.5, 0.5, 0))
+        # cmap = get_linear_cmap((0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+        cmap = get_mpl_cmap("viridis")
+
         # cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
-        print(ColorConverter().to_rgb(self.state.color))
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()
 

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -8,9 +8,12 @@ from matplotlib.colors import ColorConverter
 from glue.core.data import Subset, Data
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
-from .colors import get_linear_cmap, get_mpl_cmap, get_translucent_cmap
+from .colors import get_mpl_cmap, get_translucent_cmap
 from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
+
+
+COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode'])
 
 
 class DataProxy(object):
@@ -155,11 +158,15 @@ class VolumeLayerArtist(VispyLayerArtist):
         ARRAY_CACHE.pop(self.id, None)
         PIXEL_CACHE.pop(self.id, None)
 
-    def _update_cmap_from_color(self):
-        # cmap = get_linear_cmap((0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
-        cmap = get_mpl_cmap("viridis")
+    def _update_cmap(self):
+        print(self.state.cmap)
+        if self.state.color_mode == "Fixed":
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
+        else:
+            cmap = get_mpl_cmap(self.state.cmap)
 
-        # cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
+        print(cmap)
+
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()
 
@@ -229,8 +236,8 @@ class VolumeLayerArtist(VispyLayerArtist):
         self._last_viewer_state.update(self._viewer_state.as_dict())
         self._last_layer_state.update(self.state.as_dict())
 
-        if force or 'color' in changed:
-            self._update_cmap_from_color()
+        if force or len(changed & COLOR_PROPERTIES) > 0:
+            self._update_cmap()
 
         if force or 'vmin' in changed or 'vmax' in changed:
             self._update_limits()

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -62,3 +62,6 @@ class VolumeLayerState(VispyLayerState):
 
     def update_priority(self, name):
         return 0 if name.endswith(('vmin', 'vmax')) else 1
+
+    def flip_limits(self):
+        self.lim_helper.flip_limits()

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -1,3 +1,4 @@
+from glue.config import colormaps
 from glue.core import Subset
 from echo import (CallbackProperty, SelectionCallbackProperty,
                   delay_callback)
@@ -16,6 +17,8 @@ class VolumeLayerState(VispyLayerState):
     attribute = SelectionCallbackProperty()
     vmin = CallbackProperty()
     vmax = CallbackProperty()
+    color_mode = SelectionCallbackProperty()
+    cmap = CallbackProperty()
     subset_mode = CallbackProperty('data')
     _limits_cache = CallbackProperty({})
 
@@ -34,9 +37,13 @@ class VolumeLayerState(VispyLayerState):
                                                      lower='vmin', upper='vmax',
                                                      cache=self._limits_cache)
 
+        VolumeLayerState.color_mode.set_choices(self, ['Fixed', 'Linear'])
+
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:
             self._on_layer_change()
+
+        self.cmap = colormaps.members[0][1]
 
         if isinstance(self.layer, Subset):
             self.vmin = 0

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -44,6 +44,8 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.valuetext_vmin.hide()
             self.ui.valuetext_vmax.hide()
             self.ui.label_limits.hide()
+            self.ui.label_color_mode.hide()
+            self.ui.combotext_color_mode.hide()
         else:
             self.ui.radio_subset_outline.hide()
             self.ui.radio_subset_data.hide()

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -67,4 +67,3 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.color_color.hide()
             self.ui.label_cmap.show()
             self.ui.combodata_cmap.show()
-

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -27,6 +27,9 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
         self.layer_artist = layer_artist
         self.layer = layer_artist.layer
 
+        self._update_color_mode()
+        self.state.add_callback('color_mode', self._update_color_mode)
+
         # autoconnect needs to come after setting up the component IDs
         connect_kwargs = {'value_alpha': dict(value_range=(0., 1.))}
         self._connections = autoconnect_callbacks_to_qt(self.state, self.ui, connect_kwargs)
@@ -51,3 +54,17 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.state.subset_mode = 'outline'
         else:
             self.state.subset_mode = 'data'
+
+    def _update_color_mode(self, *args):
+        fixed_color = self.state.color_mode == "Fixed"
+        if fixed_color:
+            self.ui.label_color.show()
+            self.ui.color_color.show()
+            self.ui.label_cmap.hide()
+            self.ui.combodata_cmap.hide()
+        else:
+            self.ui.label_color.hide()
+            self.ui.color_color.hide()
+            self.ui.label_cmap.show()
+            self.ui.combodata_cmap.show()
+

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -18,7 +18,7 @@
     <number>5</number>
    </property>
    <item row="3" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_color_mode">
      <property name="text">
       <string>Color mode:</string>
      </property>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>212</width>
-    <height>106</height>
+    <width>292</width>
+    <height>191</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,38 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <property name="margin">
-    <number>5</number>
-   </property>
-   <item row="2" column="2">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Color mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_subset_mode">
+     <property name="text">
+      <string>Subset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_att">
+     <property name="text">
+      <string>Attribute:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="valuetext_vmax"/>
+   </item>
+   <item row="8" column="0" colspan="3">
     <widget class="QSlider" name="value_alpha">
      <property name="maximum">
       <number>100</number>
@@ -30,38 +58,44 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Attribute:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_subset_mode">
-     <property name="text">
-      <string>Subset:</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
     <widget class="QLineEdit" name="valuetext_vmin"/>
    </item>
-   <item row="2" column="1">
+   <item row="9" column="2">
+    <widget class="QRadioButton" name="radio_subset_outline">
+     <property name="text">
+      <string>Outline</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="combotext_color_mode">
+     <property name="currentText">
+      <string>Fixed</string>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Fixed</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Linear</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_cmap">
+     <property name="text">
+      <string>Colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
     <widget class="QColorBox" name="color_color">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -74,31 +108,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
+   <item row="5" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap"/>
    </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="valuetext_vmax"/>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combosel_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QRadioButton" name="radio_subset_outline">
-     <property name="text">
-      <string>Outline</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="10" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -111,12 +124,38 @@
      </property>
     </spacer>
    </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
+     <property name="text">
+      <string>Limits:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
    <class>QColorBox</class>
    <extends>QLabel</extends>
+   <header>glue_qt.utils.colors</header>
+  </customwidget>
+  <customwidget>
+   <class>QColormapCombo</class>
+   <extends>QComboBox</extends>
    <header>glue_qt.utils.colors</header>
   </customwidget>
  </customwidgets>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>191</height>
+    <height>214</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,56 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_color_mode">
      <property name="text">
       <string>Color mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="valuetext_vmin"/>
+   </item>
+   <item row="1" column="3" alignment="Qt::AlignLeft">
+    <widget class="QLineEdit" name="valuetext_vmax"/>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <widget class="QColormapCombo" name="combodata_cmap"/>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
@@ -38,37 +84,48 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="combosel_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_color_mode"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
+     <property name="text">
+      <string>Limits:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="valuetext_vmax"/>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QSlider" name="value_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="valuetext_vmin"/>
-   </item>
-   <item row="9" column="2">
+   <item row="9" column="3">
     <widget class="QRadioButton" name="radio_subset_outline">
      <property name="text">
       <string>Outline</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_cmap">
+     <property name="text">
+      <string>Colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2" alignment="Qt::AlignHCenter">
+    <widget class="QToolButton" name="button_flip_limits">
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
     <widget class="QComboBox" name="combotext_color_mode">
      <property name="currentText">
       <string>Fixed</string>
@@ -88,29 +145,6 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_cmap">
-     <property name="text">
-      <string>Colormap:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QColormapCombo" name="combodata_cmap"/>
-   </item>
    <item row="10" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -123,27 +157,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_color">
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
@@ -2,6 +2,7 @@ import sys
 import pytest
 import numpy as np
 
+from glue.config import colormaps
 from glue.core import DataCollection, Data
 from glue_qt.app.application import GlueApplication
 from glue.core.component import Component
@@ -65,7 +66,7 @@ def test_volume_viewer(tmpdir):
     layer_state.alpha = 0.8
 
     layer_state.color = "#ff0000"
-    layer_state.cmap = "Red-Blue"
+    layer_state.cmap = colormaps['Red-Blue']
     layer_state.color_mode = "Fixed"
 
     # Check that writing a session works as expected.
@@ -106,7 +107,7 @@ def test_volume_viewer(tmpdir):
     assert layer_artist.alpha == 0.8
 
     assert layer_state.color == "#ff0000"
-    assert layer_state.cmap == "Red-Blue"
+    assert layer_state.cmap == colormaps['Red-Blue']
     assert layer_state.color_mode == "Fixed"
 
     ga2.close()

--- a/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
@@ -64,6 +64,10 @@ def test_volume_viewer(tmpdir):
     layer_state.vmax = 0.9
     layer_state.alpha = 0.8
 
+    layer_state.color = "#ff0000"
+    layer_state.cmap = "Red-Blue"
+    layer_state.color_mode = "Fixed"
+
     # Check that writing a session works as expected.
 
     session_file = tmpdir.join('test_volume_viewer.glu').strpath
@@ -100,6 +104,10 @@ def test_volume_viewer(tmpdir):
     assert layer_artist.vmin == 0.1
     assert layer_artist.vmax == 0.9
     assert layer_artist.alpha == 0.8
+
+    assert layer_state.color == "#ff0000"
+    assert layer_state.cmap == "Red-Blue"
+    assert layer_state.color_mode == "Fixed"
 
     ga2.close()
 

--- a/glue_vispy_viewers/volume/tests/test_colors.py
+++ b/glue_vispy_viewers/volume/tests/test_colors.py
@@ -1,19 +1,25 @@
 from re import sub
 
-from glue_vispy_viewers.volume.colors import create_cmap_template, get_translucent_cmap
+from glue.config import colormaps
+from glue_vispy_viewers.volume.colors import create_cmap_template, get_mpl_cmap, \
+                                             get_translucent_cmap
 
 
 def clean_template(template):
-    return sub("(    |\n)", "", template)
+    return sub("( |\n)", "", template)
 
 
 def test_create_cmap_template():
 
     n_colors = 4
-    template = create_cmap_template(n=n_colors)
+    template = clean_template(create_cmap_template(n=n_colors))
 
-    assert clean_template(template) == clean_template("""
-    vec4 translucent_colormap(float t) {
+    # vispy adds some extra code to the GLSL map for mapping bad values (e.g. NaN)
+    # to a default color, so we need to account for that.
+    # If this becomes more complicated we could use a regex, but with all of the parentheses
+    # and brackets this feels simpler
+    template_start = clean_template("vec4 translucent_colormap(float t) {")
+    template_end = clean_template("""
         if (t <= 0.25)
             { return $color_0; }
         if (t <= 0.5)
@@ -23,14 +29,46 @@ def test_create_cmap_template():
         return $color_3;
     }
     """)
+    assert template.startswith(template_start)
+    assert template.endswith(template_end)
 
 
 def test_translucent_cmap():
     color = (0.3, 0.5, 0.7)
     cmap_cls = get_translucent_cmap(*color)
+    template = clean_template(cmap_cls.glsl_map)
 
-    assert clean_template(cmap_cls.glsl_map) == clean_template("""
-    vec4 translucent_fire(float t) {
+    template_start = clean_template("vec4 translucent_fire(float t) {")
+    template_end = clean_template("""
         return vec4(0.3, 0.5, 0.7, t);
     }
     """)
+    assert template.startswith(template_start)
+    assert template.endswith(template_end)
+
+
+def test_linear_cmap():
+
+    colormap = colormaps['Red-Blue']
+    cmap = get_mpl_cmap(colormap)
+    assert len(cmap.colors) == 256
+
+    template = create_cmap_template(256)
+    template_start, template_end = [clean_template(t) for t in template.split("\n", maxsplit=1)]
+    template = clean_template(template)
+    assert template.startswith(template_start)
+    assert template.endswith(template_end)
+
+
+def test_listed_cmap():
+
+    colormap = colormaps['Viridis']
+    cmap = get_mpl_cmap(colormap)
+    n_colors = len(colormap.colors)
+    assert len(cmap.colors) == n_colors
+
+    template = create_cmap_template(n_colors)
+    template_start, template_end = [clean_template(t) for t in template.split("\n", maxsplit=1)]
+    template = clean_template(template)
+    assert template.startswith(template_start)
+    assert template.endswith(template_end)

--- a/glue_vispy_viewers/volume/tests/test_colors.py
+++ b/glue_vispy_viewers/volume/tests/test_colors.py
@@ -1,6 +1,10 @@
-import pytest
+from re import sub
 
 from glue_vispy_viewers.volume.colors import create_cmap_template, get_translucent_cmap
+
+
+def clean_template(template):
+    return sub("(    |\n)", "", template)
 
 
 def test_create_cmap_template():
@@ -8,26 +12,25 @@ def test_create_cmap_template():
     n_colors = 4
     template = create_cmap_template(n=n_colors)
 
-    assert template == f"""
-        vec4 translucent_colormap(float t) {{
-            if (t <= 0.25)
-                {{ return $color_0; }}
-            if (t <= 0.5)
-                {{ return $color_1; }}
-            if (t <= 0.75) {{
-                {{ return $color_2; }}
-            }}
-            return $color_3;
-        }}
-    """
+    assert clean_template(template) == clean_template("""
+    vec4 translucent_colormap(float t) {
+        if (t <= 0.25)
+            { return $color_0; }
+        if (t <= 0.5)
+            { return $color_1; }
+        if (t <= 0.75)
+            { return $color_2; }
+        return $color_3;
+    }
+    """)
 
 
 def test_translucent_cmap():
     color = (0.3, 0.5, 0.7)
     cmap_cls = get_translucent_cmap(*color)
 
-    assert cmap_cls.glsl_map == """
+    assert clean_template(cmap_cls.glsl_map) == clean_template("""
     vec4 translucent_fire(float t) {
         return vec4(0.3, 0.5, 0.7, t);
     }
-    """
+    """)

--- a/glue_vispy_viewers/volume/tests/test_colors.py
+++ b/glue_vispy_viewers/volume/tests/test_colors.py
@@ -1,0 +1,33 @@
+import pytest
+
+from glue_vispy_viewers.volume.colors import create_cmap_template, get_translucent_cmap
+
+
+def test_create_cmap_template():
+
+    n_colors = 4
+    template = create_cmap_template(n=n_colors)
+
+    assert template == f"""
+        vec4 translucent_colormap(float t) {{
+            if (t <= 0.25)
+                {{ return $color_0; }}
+            if (t <= 0.5)
+                {{ return $color_1; }}
+            if (t <= 0.75) {{
+                {{ return $color_2; }}
+            }}
+            return $color_3;
+        }}
+    """
+
+
+def test_translucent_cmap():
+    color = (0.3, 0.5, 0.7)
+    cmap_cls = get_translucent_cmap(*color)
+
+    assert cmap_cls.glsl_map == """
+    vec4 translucent_fire(float t) {
+        return vec4(0.3, 0.5, 0.7, t);
+    }
+    """


### PR DESCRIPTION
This PR implements a request that I've gotten a decent number of times while working on the augmented reality plugin, which is to allow using colormaps in the volume viewer. While I've been able to do that using post-processing on the outputs from `glue-ar`, I figured it might be nice to have the option in glue.

The idea here is pretty straightforward - currently we allow a single color - say it has components (R, G, B) - and inside the shader use a colormap t -> (R, G, B, t). This PR modifies things so that if we're using a colormap, say defined by C(t) = (R(t), G(t), B(t)), then inside the shader we use t -> (R(t), G(t), B(t), t). Basically, instead of constant RGB values, we use the appropriate one from the colormap based on the value of t. To do this, I've added a small utility function for writing the GLSL for a colormap function with a given number of colors.

As it currently stands, this PR works for either a `ListedColormap` or a `LinearSegmentedColormap`. As an example, here's a piece of the Edenhofer dustmap using the Plasma colormap

<img width="540" alt="Screenshot 2025-05-19 at 5 01 53 PM" src="https://github.com/user-attachments/assets/beeb65a4-e8ed-4bd8-b0ab-e6f65aec2b21" />