### PR TITLE
Add support for stretches in volume viewer

### DIFF
--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,15 +1,21 @@
-from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch
+from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch, DictRegistry
 from matplotlib.colors import ListedColormap
 from vispy.color import BaseColormap
 
 
-STRETCHES_GLSL = {
-    LogStretch: "log({stretch.a} * {parameter} + 1.0) / log({stretch.a} + 1.0)",
-    SqrtStretch: "sqrt({parameter})",
-    AsinhStretch: "log({parameter} / {stretch.a} + sqrt(pow({parameter} / {stretch.a}, 2) + 1)) / "
-                  "log(1.0 / {stretch.a} + sqrt(pow(1.0 / {stretch.a}, 2) + 1))",
-    LinearStretch: "{parameter}",
-}
+class GLSLStretchRegistry(DictRegistry):
+
+    def add(self, stretch_cls, glsl):
+        self.members[stretch_cls] = glsl
+
+
+stretch_glsl = GLSLStretchRegistry()
+stretch_glsl.add(LogStretch, "log({stretch.a} * {parameter} + 1.0) / log({stretch.a} + 1.0)")
+stretch_glsl.add(SqrtStretch, "sqrt({parameter})")
+stretch_glsl.add(AsinhStretch,
+                 "log({parameter} / {stretch.a} + sqrt(pow({parameter} / {stretch.a}, 2) + 1)) / "
+                 "log(1.0 / {stretch.a} + sqrt(pow(1.0 / {stretch.a}, 2) + 1))")
+stretch_glsl.add(LinearStretch, "{parameter}")
 
 
 def create_cmap_template(n, stretch_glsl):
@@ -28,7 +34,7 @@ def create_cmap_template(n, stretch_glsl):
 
 
 def glsl_for_stretch(stretch, parameter="t"):
-    template = STRETCHES_GLSL.get(type(stretch), "{param}")
+    template = stretch_glsl.members.get(type(stretch), "{param}")
     return template.format(stretch=stretch, parameter=parameter)
 
 

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,6 +1,14 @@
-from glue.config import AsinhStretch, LogStretch, SqrtStretch
+from glue.config import AsinhStretch, LinearStretch, LogStretch, SqrtStretch
 from matplotlib.colors import ListedColormap
 from vispy.color import BaseColormap
+
+
+STRETCHES_GLSL = {
+    LogStretch: "log({stretch.a} * {parameter} + 1.0) / log({stretch.a} + 1.0)",
+    SqrtStretch: "sqrt({parameter})",
+    AsinhStretch: "log({parameter} / {stretch.a} + sqrt(pow({parameter} / {stretch.a}, 2) + 1)) / log(1.0 / {stretch.a} + sqrt(pow(1.0 / {stretch.a}, 2) + 1))",
+    LinearStretch: "{parameter}",
+}
 
 
 def create_cmap_template(n, stretch_glsl):
@@ -18,16 +26,9 @@ def create_cmap_template(n, stretch_glsl):
     return "\n".join(lines)
 
 
-def glsl_for_stretch(stretch, param="t"):
-    if isinstance(stretch, LogStretch):
-        return f"log({stretch.a} * {param} + 1.0) / log({stretch.a} + 1.0)"
-    elif isinstance(stretch, SqrtStretch):
-        return f"sqrt({param})"
-    elif isinstance(stretch, AsinhStretch):
-        reciprocal = 1 / stretch.a
-        param_rec = f"{param} * {reciprocal}"
-        return f"log({param_rec} + sqrt(pow({param_rec}, 2) + 1)) / log({reciprocal} + sqrt(pow({reciprocal}, 2) + 1))"
-    return param
+def glsl_for_stretch(stretch, parameter="t"):
+    template = STRETCHES_GLSL.get(type(stretch), "{param}")
+    return template.format(stretch=stretch, parameter=parameter)
 
 
 def get_translucent_cmap(r, g, b, stretch):

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -1,13 +1,16 @@
+from glue.config import AsinhStretch, LogStretch, SqrtStretch
 from matplotlib.colors import ListedColormap
 from vispy.color import BaseColormap
 
 
-def create_cmap_template(n):
+def create_cmap_template(n, stretch_glsl):
+    ts = tuple((i + 1) / n for i in range(n-1))
     lines = [
         "vec4 translucent_colormap(float t) {",
+        f"    float s = {stretch_glsl};"
     ]
-    for i in range(n-1):
-        lines.append(f"    if (t <= {(i+1) / n})")
+    for i, t in enumerate(ts):
+        lines.append(f"    if (s <= {t})")
         lines.append(f"        {{ return $color_{i}; }}")
     lines.append(f"    return $color_{n-1};")
     lines.append("}")
@@ -15,31 +18,48 @@ def create_cmap_template(n):
     return "\n".join(lines)
 
 
-def get_translucent_cmap(r, g, b):
+def glsl_for_stretch(stretch, param="t"):
+    if isinstance(stretch, LogStretch):
+        return f"log({stretch.a} * {param} + 1.0) / log({stretch.a} + 1.0)"
+    elif isinstance(stretch, SqrtStretch):
+        return f"sqrt({param})"
+    elif isinstance(stretch, AsinhStretch):
+        reciprocal = 1 / stretch.a
+        param_rec = f"{param} * {reciprocal}"
+        return f"log({param_rec} + sqrt(pow({param_rec}, 2) + 1)) / log({reciprocal} + sqrt(pow({reciprocal}, 2) + 1))"
+    return param
+
+
+def get_translucent_cmap(r, g, b, stretch):
+
+    func = glsl_for_stretch(stretch)
 
     class TranslucentCmap(BaseColormap):
         glsl_map = """
         vec4 translucent_fire(float t) {{
-            return vec4({0}, {1}, {2}, t);
+            return vec4({0}, {1}, {2}, {3});
         }}
-        """.format(r, g, b)
+        """.format(r, g, b, func)
 
     return TranslucentCmap()
 
 
-def get_mpl_cmap(cmap):
+def get_mpl_cmap(cmap, stretch):
 
     if isinstance(cmap, ListedColormap):
         colors = cmap.colors
         n_colors = len(colors)
-        colors = [color + [index / n_colors] for index, color in enumerate(colors)]
+        ts = stretch([index / n_colors for index in range(len(colors))])
+        colors = [color + [t] for t, color in zip(ts, colors)]
     else:
         n_colors = 256
-        colors = [cmap(index / n_colors)[:3] + (index / n_colors,) for index in range(n_colors)]
+        ts = stretch([index / n_colors for index in range(n_colors)])
+        colors = [cmap(t)[:3] + (t,) for t in ts]
 
-    template = create_cmap_template(n_colors)
+    stretch_glsl = glsl_for_stretch(stretch)
+    template = create_cmap_template(n_colors, stretch_glsl)
 
     class MatplotlibCmap(BaseColormap):
         glsl_map = template
-
+    
     return MatplotlibCmap(colors=colors)

--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -6,7 +6,8 @@ from vispy.color import BaseColormap
 STRETCHES_GLSL = {
     LogStretch: "log({stretch.a} * {parameter} + 1.0) / log({stretch.a} + 1.0)",
     SqrtStretch: "sqrt({parameter})",
-    AsinhStretch: "log({parameter} / {stretch.a} + sqrt(pow({parameter} / {stretch.a}, 2) + 1)) / log(1.0 / {stretch.a} + sqrt(pow(1.0 / {stretch.a}, 2) + 1))",
+    AsinhStretch: "log({parameter} / {stretch.a} + sqrt(pow({parameter} / {stretch.a}, 2) + 1)) / "
+                  "log(1.0 / {stretch.a} + sqrt(pow(1.0 / {stretch.a}, 2) + 1))",
     LinearStretch: "{parameter}",
 }
 
@@ -62,5 +63,5 @@ def get_mpl_cmap(cmap, stretch):
 
     class MatplotlibCmap(BaseColormap):
         glsl_map = template
-    
+
     return MatplotlibCmap(colors=colors)

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.py
@@ -26,6 +26,11 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
 
     cmap_items = traitlets.List().tag(sync=True)
 
+    # Stretch
+
+    stretch_items = traitlets.List().tag(sync=True)
+    stretch_selected = traitlets.Int(allow_none=True).tag(sync=True)
+
     subset = traitlets.Bool().tag(sync=True)
 
     def __init__(self, layer_state):
@@ -37,6 +42,7 @@ class Volume3DLayerStateWidget(v.VuetifyTemplate):
         self.subset = isinstance(layer_state.layer, Subset)
 
         link_glue_choices(self, layer_state, "attribute")
+        link_glue_choices(self, layer_state, "stretch")
         link_glue_choices(self, layer_state, "color_mode")
 
         self.cmap_items = [

--- a/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
+++ b/glue_vispy_viewers/volume/jupyter/layer_state_widget.vue
@@ -14,6 +14,9 @@
           </div>
         </template>
         <div>
+           <v-select label="stretch" :items="stretch_items" v-model="stretch_selected" hide-details />
+       </div> 
+        <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
             <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
         </div>

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -13,7 +13,7 @@ from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
 
-COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode'])
+COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode', 'stretch'])
 
 
 class DataProxy(object):
@@ -160,9 +160,9 @@ class VolumeLayerArtist(VispyLayerArtist):
 
     def _update_cmap(self):
         if self.state.color_mode == "Fixed":
-            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color))
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color), self.state.stretch_object)
         else:
-            cmap = get_mpl_cmap(self.state.cmap)
+            cmap = get_mpl_cmap(self.state.cmap, self.state.stretch_object)
 
         self._multivol.set_cmap(self.id, cmap)
         self.redraw()

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -160,7 +160,8 @@ class VolumeLayerArtist(VispyLayerArtist):
 
     def _update_cmap(self):
         if self.state.color_mode == "Fixed":
-            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color), self.state.stretch_object)
+            cmap = get_translucent_cmap(*ColorConverter().to_rgb(self.state.color),
+                                        self.state.stretch_object)
         else:
             cmap = get_mpl_cmap(self.state.cmap, self.state.stretch_object)
 

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -13,7 +13,7 @@ from .layer_state import VolumeLayerState
 from ..common.layer_artist import VispyLayerArtist
 
 
-COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode', 'stretch'])
+COLOR_PROPERTIES = set(['cmap', 'color', 'color_mode', 'stretch', 'stretch_parameters'])
 
 
 class DataProxy(object):

--- a/glue_vispy_viewers/volume/layer_state.py
+++ b/glue_vispy_viewers/volume/layer_state.py
@@ -4,12 +4,13 @@ from echo import (CallbackProperty, SelectionCallbackProperty,
                   delay_callback)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper
+from glue.viewers.common.stretch_state_mixin import StretchStateMixin
 from ..common.layer_state import VispyLayerState
 
 __all__ = ['VolumeLayerState']
 
 
-class VolumeLayerState(VispyLayerState):
+class VolumeLayerState(VispyLayerState, StretchStateMixin):
     """
     A state object for volume layers
     """
@@ -38,6 +39,8 @@ class VolumeLayerState(VispyLayerState):
                                                      cache=self._limits_cache)
 
         VolumeLayerState.color_mode.set_choices(self, ['Fixed', 'Linear'])
+
+        self.setup_stretch_callback()
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -43,6 +43,7 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.radio_subset_data.toggled.connect(self._update_subset_mode)
             self.ui.valuetext_vmin.hide()
             self.ui.valuetext_vmax.hide()
+            self.ui.button_flip_limits.hide()
             self.ui.label_limits.hide()
             self.ui.label_color_mode.hide()
             self.ui.combotext_color_mode.hide()

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.py
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.py
@@ -43,7 +43,6 @@ class VolumeLayerStyleWidget(QtWidgets.QWidget):
             self.ui.radio_subset_data.toggled.connect(self._update_subset_mode)
             self.ui.valuetext_vmin.hide()
             self.ui.valuetext_vmax.hide()
-            self.ui.button_flip_limits.hide()
             self.ui.label_limits.hide()
             self.ui.label_color_mode.hide()
             self.ui.combotext_color_mode.hide()

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>214</height>
+    <height>246</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -101,13 +101,6 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_cmap">
-     <property name="text">
-      <string>Colormap:</string>
-     </property>
-    </widget>
-   </item>
    <item row="9" column="1">
     <widget class="QRadioButton" name="radio_subset_data">
      <property name="text">
@@ -145,6 +138,26 @@
      </item>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_cmap">
+     <property name="text">
+      <string>Colormap:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
    <item row="10" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -157,6 +170,37 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
+     <property name="text">
+      <string>Limits:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_stretch">
+     <property name="text">
+      <string>Stretch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_stretch"/>
    </item>
   </layout>
  </widget>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -17,13 +17,6 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_color">
-     <property name="text">
-      <string>Color:</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_color_mode">
      <property name="text">

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -77,9 +77,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_color_mode"/>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_limits">
      <property name="text">
@@ -155,20 +152,6 @@
     <widget class="QLabel" name="label_color">
      <property name="text">
       <string>Color:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
      </property>
     </widget>
    </item>

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -145,19 +145,6 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
    <item row="10" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">

--- a/glue_vispy_viewers/volume/qt/layer_style_widget.ui
+++ b/glue_vispy_viewers/volume/qt/layer_style_widget.ui
@@ -17,98 +17,14 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_color_mode">
-     <property name="text">
-      <string>Color mode:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="valuetext_vmin"/>
-   </item>
-   <item row="1" column="3" alignment="Qt::AlignLeft">
-    <widget class="QLineEdit" name="valuetext_vmax"/>
-   </item>
-   <item row="5" column="1" colspan="3">
-    <widget class="QColormapCombo" name="combodata_cmap"/>
-   </item>
-   <item row="8" column="0" colspan="4">
-    <widget class="QSlider" name="value_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="3">
-    <widget class="QComboBox" name="combosel_attribute">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_subset_mode">
-     <property name="text">
-      <string>Subset:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_att">
-     <property name="text">
-      <string>Attribute:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_limits">
-     <property name="text">
-      <string>Limits:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="3">
+   <item row="9" column="2">
     <widget class="QRadioButton" name="radio_subset_outline">
      <property name="text">
       <string>Outline</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <widget class="QRadioButton" name="radio_subset_data">
-     <property name="text">
-      <string>Data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" alignment="Qt::AlignHCenter">
-    <widget class="QToolButton" name="button_flip_limits">
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
+   <item row="3" column="1" colspan="2">
     <widget class="QComboBox" name="combotext_color_mode">
      <property name="currentText">
       <string>Fixed</string>
@@ -128,12 +44,86 @@
      </item>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_color">
+     <property name="text">
+      <string>Color:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_att">
+     <property name="text">
+      <string>Attribute:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="radio_subset_data">
+     <property name="text">
+      <string>Data</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_limits">
+     <property name="text">
+      <string>Limits:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_subset_mode">
+     <property name="text">
+      <string>Subset:</string>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_cmap">
      <property name="text">
       <string>Colormap:</string>
      </property>
     </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_color_mode">
+     <property name="text">
+      <string>Color mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_stretch"/>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="valuetext_vmin"/>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap"/>
    </item>
    <item row="10" column="1">
     <spacer name="verticalSpacer">
@@ -148,10 +138,10 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_color">
-     <property name="text">
-      <string>Color:</string>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combosel_attribute">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
@@ -162,8 +152,8 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="3">
-    <widget class="QComboBox" name="combosel_stretch"/>
+   <item row="1" column="2" alignment="Qt::AlignLeft">
+    <widget class="QLineEdit" name="valuetext_vmax"/>
    </item>
   </layout>
  </widget>

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ setup_requires = setuptools_scm
 install_requires =
     numpy
     pyopengl
-    glue-core>=1.13.1
+    glue-core>=1.17.0
     echo>=0.6
     scipy
     matplotlib


### PR DESCRIPTION
This PR builds on top of #395 and adds support for stretches for the volume viewer. This is done by creating a GLSL template string for each stretch type (which are stored in a `stretch_glsl` registry so that a plugin can extend this functionality if it wants to). At least in my local testing, `asinh` wasn't a builtin GLSL function so this uses the log/sqrt expression for it.

Marking this as a draft as I haven't set up the UI for the Jupyter volume viewer yet.