### PR TITLE
Make volume viewer colormap construction more flexible

### DIFF
--- a/glue_vispy_viewers/volume/colors.py
+++ b/glue_vispy_viewers/volume/colors.py
@@ -57,12 +57,12 @@ def get_mpl_cmap(cmap, stretch):
     if isinstance(cmap, ListedColormap):
         colors = cmap.colors
         n_colors = len(colors)
-        ts = stretch([index / n_colors for index in range(len(colors))])
-        colors = [color + [t] for t, color in zip(ts, colors)]
+        ts = stretch([index / n_colors for index in range(n_colors)])
+        colors = [[*color, t] for t, color in zip(ts, colors)]
     else:
         n_colors = 256
         ts = stretch([index / n_colors for index in range(n_colors)])
-        colors = [cmap(t)[:3] + (t,) for t in ts]
+        colors = [[*cmap(t)[:3], t] for t in ts]
 
     stretch_glsl = glsl_for_stretch(stretch)
     template = create_cmap_template(n_colors, stretch_glsl)


### PR DESCRIPTION
While doing some work with some `yt` colormaps, a few of those colormaps have `colors` members that are numpy arrays. Our current colormap construction for the volume viewer assumes that `colors` is a list, like it is for the matplotlib listed colormaps. This causes element-wise addition rather than concatenation when constructing the RGBA lists with those `yt` maps. This PR modifies the RGBA color construction to handle either case.
