### PR TITLE
Use pixel matrix for component ID mapping

### DIFF
--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -7,7 +7,7 @@ from matplotlib.colors import ColorConverter
 
 from glue.core.data import Subset, Data
 from glue.core.link_manager import pixel_cid_to_pixel_cid_matrix
-from glue.core.exceptions import IncompatibleAttribute
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from .colors import get_mpl_cmap, get_translucent_cmap
 from .layer_state import VolumeLayerState
@@ -106,7 +106,7 @@ class DataProxy(object):
                     target_data=self.viewer_state.reference_data,
                     subset_state=subset_state,
                     cache_id=self.layer_artist.id)
-            except IncompatibleAttribute:
+            except (IncompatibleDataException, IncompatibleAttribute):
                 self.layer_artist.disable_incompatible_subset()
                 return np.broadcast_to(0, shape)
             else:
@@ -118,7 +118,7 @@ class DataProxy(object):
                     target_data=self.viewer_state.reference_data,
                     target_cid=self.layer_artist.state.attribute,
                     cache_id=self.layer_artist.id)
-            except IncompatibleAttribute:
+            except (IncompatibleDataException, IncompatibleAttribute):
                 self.layer_artist.disable('Layer data is not fully linked to reference data')
                 return np.broadcast_to(0, shape)
             else:

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -67,13 +67,9 @@ class DataProxy(object):
         if self.layer_artist is None or self.viewer_state is None:
             return np.broadcast_to(0, shape)
 
-        order = self._pixel_cid_order()
         reference_axes = [self.viewer_state.x_att.axis,
                           self.viewer_state.y_att.axis,
                           self.viewer_state.z_att.axis]
-        if set(reference_axes) > set([t for t in order if t is not None]):
-            self.layer_artist.disable('Layer data is not fully linked to x/y/z attributes')
-            return np.broadcast_to(0, shape)
 
         # For this method, we make use of Data.compute_fixed_resolution_buffer,
         # which requires us to specify bounds in the form (min, max, nsteps).

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -34,7 +34,12 @@ class DataProxy(object):
     def _pixel_cid_order(self):
         mat = pixel_cid_to_pixel_cid_matrix(self.viewer_state.reference_data,
                                             self.layer_artist.layer)
-        return [np.argmax(mat[:, i]) for i in range(mat.shape[1])]
+        order = []
+        for i in range(mat.shape[1]):
+            idx = np.argmax(mat[:, i])
+            order.append(idx if mat[idx, i] else None)
+        return order
+
 
     @property
     def shape(self):

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -32,8 +32,11 @@ class DataProxy(object):
         return self._viewer_state()
 
     def _pixel_cid_order(self):
+        data = self.layer_artist.layer
+        if isinstance(self.layer_artist.layer, Subset):
+            data = data.data
         mat = pixel_cid_to_pixel_cid_matrix(self.viewer_state.reference_data,
-                                            self.layer_artist.layer)
+                                            data)
         order = []
         for i in range(mat.shape[1]):
             idx = np.argmax(mat[:, i])

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib.colors import ColorConverter
 
 from glue.core.data import Subset, Data
-from glue.core.link_manager import equivalent_pixel_cids, pixel_cid_to_pixel_cid_matrix
+from glue.core.link_manager import pixel_cid_to_pixel_cid_matrix
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from .colors import get_mpl_cmap, get_translucent_cmap
@@ -39,7 +39,6 @@ class DataProxy(object):
             idx = np.argmax(mat[:, i])
             order.append(idx if mat[idx, i] else None)
         return order
-
 
     @property
     def shape(self):

--- a/glue_vispy_viewers/volume/layer_artist.py
+++ b/glue_vispy_viewers/volume/layer_artist.py
@@ -71,7 +71,7 @@ class DataProxy(object):
         reference_axes = [self.viewer_state.x_att.axis,
                           self.viewer_state.y_att.axis,
                           self.viewer_state.z_att.axis]
-        if order is not None and not set(reference_axes) <= set(order):
+        if set(reference_axes) > set([t for t in order if t is not None]):
             self.layer_artist.disable('Layer data is not fully linked to x/y/z attributes')
             return np.broadcast_to(0, shape)
 

--- a/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
+++ b/glue_vispy_viewers/volume/qt/tests/test_volume_viewer.py
@@ -326,7 +326,7 @@ def test_3d_4d_layers():
 
     volume.state.y_att = data_4d.pixel_component_ids[3]
 
-    assert not layer_3d.enabled
+    assert layer_3d.enabled
 
     ga.close()
 
@@ -395,7 +395,7 @@ def test_data_proxy_shape():
     volume.state.y_att = data_4d.pixel_component_ids[1]
     volume.state.z_att = data_4d.pixel_component_ids[2]
 
-    proxy = DataProxy(volume.state, layer.state)
+    proxy = DataProxy(volume.state, layer)
     assert proxy.shape == (2, 4, 5)
 
     volume.state.x_att = data_4d.pixel_component_ids[3]
@@ -409,13 +409,13 @@ def test_data_proxy_shape():
     volume.add_data(data_4d_2)
     layer2 = volume.layers[-1]
 
-    proxy2 = DataProxy(volume.state, layer2.state)
+    proxy2 = DataProxy(volume.state, layer2)
     assert proxy2.shape == (0, 0, 0)
 
     volume.state.x_att = data_4d.pixel_component_ids[0]
     volume.state.y_att = data_4d.pixel_component_ids[1]
     volume.state.z_att = data_4d.pixel_component_ids[2]
-    assert proxy2.shape == (0, 0, 0)
+    assert proxy2.shape == (3, 6, 11)
 
     dc.add_link(LinkSame(data_4d.pixel_component_ids[3], data_4d_2.pixel_component_ids[2]))
     assert proxy2.shape == (3, 6, 11)


### PR DESCRIPTION
While looking into some 3D viewer stuff related to e.g. https://github.com/glue-viz/glue/pull/2559, I noticed that the new approach to handling pixel component IDs introduced in #399 has a few cases that it misses.

In particular, `equivalent_pixel_cids` I think is too restrictive for the purposes of the data proxy FRB calculation. In particular, this runs into problems if we link the two dataset on the associated world coordinates, rather than the pixel coordinates directly - i.e. if I have two datasets A and B, and link my coordinates like

Pixel A <-- world2pix/pix2world --> World A <-- My link --> World B <-- world2pix/pix2world --> Pixel B

then the current approach won't find the datasets as compatible, even though this should be enough to display e.g. layer B if layer A is my reference data. The solution used here is to instead find the pixel component ID matrix and look at the relevant indices of true values. If nothing maps to a given index we just put `None` into the order.

@astrofrog does this seem reasonable?